### PR TITLE
Add arm ami support

### DIFF
--- a/modules/node-group/main.tf
+++ b/modules/node-group/main.tf
@@ -54,6 +54,7 @@ resource "aws_eks_node_group" "default" {
   version         = each.value.kubernetes_version
   tags            = module.labels.tags
   capacity_type   = each.value.node_group_capacity_type
+  ami_type        = each.value.ami_type
 
   scaling_config {
     desired_size = each.value.node_group_desired_size


### PR DESCRIPTION
# Description

Add arm ami support

example : 

node_groups = {
    tools = {
      node_group_name           = "auto"
      subnet_ids                = [""]
      ami_type                  = "AL2_ARM_64"
      node_group_volume_size    = 100
      node_group_instance_types = ["m6g.medium"]
      kubernetes_labels         = {}
      kubernetes_version        = "1.20"
      node_group_desired_size   = 1
      node_group_max_size       = 1
      node_group_min_size       = 1
      node_group_capacity_type  = "ON_DEMAND"
      node_group_volume_type   = "gp2"
    }
  }
