### PR TITLE
feat: Update aws provider version and node instance type

### DIFF
--- a/example/aws_managed/versions.tf
+++ b/example/aws_managed/versions.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.48.0"
+      version = "~> 4.0"
     }
   }
 }

--- a/example/complete/versions.tf
+++ b/example/complete/versions.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.48.0"
+      version = "~> 4.0"
     }
   }
 }

--- a/example/self_managed/main.tf
+++ b/example/self_managed/main.tf
@@ -144,7 +144,7 @@ module "eks" {
       max_size             = 7
       desired_size         = 2
       bootstrap_extra_args = "--kubelet-extra-args '--max-pods=110'"
-      instance_type        = "t4g.medium"
+      instance_type        = "t3.medium"
     }
 
     spot = {
@@ -156,7 +156,7 @@ module "eks" {
       max_size             = 7
       desired_size         = 1
       bootstrap_extra_args = "--kubelet-extra-args '--node-labels=node.kubernetes.io/lifecycle=spot'"
-      instance_type        = "t4g.medium"
+      instance_type        = "t3.medium"
     }
   }
   # Schdule Self Managed Auto Scaling node group

--- a/example/self_managed/versions.tf
+++ b/example/self_managed/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.72"
+      version = "~> 4.0"
     }
     cloudinit = {
       source  = "hashicorp/cloudinit"

--- a/main.tf
+++ b/main.tf
@@ -28,15 +28,15 @@ resource "aws_eks_cluster" "default" {
   count                     = var.enabled ? 1 : 0
   name                      = module.labels.id
   role_arn                  = join("", aws_iam_role.default.*.arn)
-  version                   = var.kubernetes_version  
+  version                   = var.kubernetes_version
   enabled_cluster_log_types = var.enabled_cluster_log_types
   tags                      = module.labels.tags
 
 
-  vpc_config {    
+  vpc_config {
     subnet_ids              = var.subnet_ids
-    endpoint_private_access = var.endpoint_private_access    
-    endpoint_public_access  = var.endpoint_public_access    
+    endpoint_private_access = var.endpoint_private_access
+    endpoint_public_access  = var.endpoint_public_access
     public_access_cidrs     = var.public_access_cidrs
     security_group_ids      = var.eks_additional_security_group_ids
   }

--- a/security_groups.tf
+++ b/security_groups.tf
@@ -17,8 +17,8 @@ resource "aws_security_group_rule" "node_group" {
   description       = "Allow all egress traffic"
   from_port         = 0
   to_port           = 0
-  protocol          = "-1" 
-  cidr_blocks       = ["0.0.0.0/0"] 
+  protocol          = "-1"
+  cidr_blocks       = ["0.0.0.0/0"]
   security_group_id = join("", aws_security_group.node_group.*.id)
   type              = "egress"
 }


### PR DESCRIPTION
## what
* Ppdated the Terraform AWS provider version for self-managed EKS to prevent bugs and errors that may occur with older versions.
* changed the instance type for the node group pools from t4g.medium to t3.micro to support the launch template in self-managed EKS cluster types.

## why
* Updating the AWS provider version ensures compatibility with other modules and prevents conflicts in the code.
* Changing the instance type allows for better integration with the launch template, improving the overall performance of the self-managed EKS cluster.