### PR TITLE
Fix: Update kubernetes provider name and tag.

### DIFF
--- a/aws_auth.tf
+++ b/aws_auth.tf
@@ -38,7 +38,7 @@ locals {
   # Note that we don't need to do this for managed Node Groups since EKS adds their roles to the ConfigMap automatically
   map_worker_roles = [
     {
-      rolearn : join("", aws_iam_role.node_groups.*.arn)
+      rolearn : aws_iam_role.node_groups.0.arn
       username : "system:node:{{EC2PrivateDNSName}}"
       groups : [
         "system:bootstrappers",
@@ -53,7 +53,7 @@ data "template_file" "kubeconfig" {
   template = file("${path.module}/kubeconfig.tpl")
 
   vars = {
-    server                     = join("", aws_eks_cluster.default.*.endpoint)
+    server                     = aws_eks_cluster.default[0].endpoint
     certificate_authority_data = local.certificate_authority_data
     cluster_name               = module.labels.id
   }
@@ -88,9 +88,9 @@ data "aws_eks_cluster_auth" "eks" {
 }
 
 provider "kubernetes" {
-  token                  = join("", data.aws_eks_cluster_auth.eks.*.token)
-  host                   = join("", data.aws_eks_cluster.eks.*.endpoint)
-  cluster_ca_certificate = base64decode(join("", data.aws_eks_cluster.eks.*.certificate_authority.0.data))
+  token                  = data.aws_eks_cluster_auth.eks[0].token
+  host                   = data.aws_eks_cluster.eks[0].endpoint
+  cluster_ca_certificate = base64decode(data.aws_eks_cluster.eks[0].certificate_authority.0.data)
 }
 
 resource "kubernetes_config_map" "aws_auth_ignore_changes" {

--- a/aws_auth.tf
+++ b/aws_auth.tf
@@ -74,7 +74,7 @@ resource "null_resource" "wait_for_cluster" {
 
 data "aws_eks_cluster" "eks" {
   count = var.enabled && var.apply_config_map_aws_auth ? 1 : 0
-  name  = join("", aws_eks_cluster.default.*.id)
+  name  = module.labels.id
 }
 
 # Get an authentication token to communicate with the EKS cluster.
@@ -84,7 +84,7 @@ data "aws_eks_cluster" "eks" {
 # https://www.terraform.io/docs/providers/aws/d/eks_cluster_auth.html
 data "aws_eks_cluster_auth" "eks" {
   count = var.enabled && var.apply_config_map_aws_auth ? 1 : 0
-  name  = join("", aws_eks_cluster.default.*.id)
+  name  = module.labels.id
 }
 
 provider "kubernetes" {

--- a/aws_node_groups.tf
+++ b/aws_node_groups.tf
@@ -5,7 +5,7 @@ module "eks_managed_node_group" {
 
   enabled = try(each.value.enabled, true)
 
-  cluster_name    = join("", aws_eks_cluster.default.*.name)
+  cluster_name    = aws_eks_cluster.default[0].name
   cluster_version = var.kubernetes_version
   vpc_security_group_ids = compact(
     concat(
@@ -72,7 +72,7 @@ module "eks_managed_node_group" {
   placement                          = try(each.value.placement, var.managed_node_group_defaults.placement, null)
 
   # IAM role
-  iam_role_arn = join("", aws_iam_role.node_groups.*.arn)
+  iam_role_arn = aws_iam_role.node_groups[0].arn
 
   tags = merge(var.tags, try(each.value.tags, var.managed_node_group_defaults.tags, {}))
 }

--- a/fargate_profile.tf
+++ b/fargate_profile.tf
@@ -6,7 +6,7 @@ module "fargate" {
   label_order      = var.label_order
   enabled          = var.enabled
   fargate_enabled  = var.fargate_enabled
-  cluster_name     = join("", aws_eks_cluster.default.*.name)
+  cluster_name     = aws_eks_cluster.default[0].name
   fargate_profiles = var.fargate_profiles
   subnet_ids       = var.subnet_ids
 

--- a/kms.tf
+++ b/kms.tf
@@ -11,7 +11,7 @@ data "aws_iam_policy_document" "cloudwatch" {
       identifiers = [
         format(
           "arn:%s:iam::%s:root",
-          join("", data.aws_partition.current.*.partition),
+          data.aws_partition.current.partition,
           data.aws_caller_identity.current.account_id
         )
       ]

--- a/locals.tf
+++ b/locals.tf
@@ -2,12 +2,9 @@ locals {
   # Encryption
   cluster_encryption_config = {
     resources        = var.cluster_encryption_config_resources
-    provider_key_arn = var.enabled ? join("", aws_kms_key.cluster.*.arn) : null
+    provider_key_arn = var.enabled ? aws_kms_key.cluster[0].arn : null
   }
-  aws_policy_prefix             = format("arn:%s:iam::aws:policy", join("", data.aws_partition.current.*.partition))
+  aws_policy_prefix             = format("arn:%s:iam::aws:policy", data.aws_partition.current[0].partition)
   create_outposts_local_cluster = length(var.outpost_config) > 0
 
 }
-
-
-

--- a/locals.tf
+++ b/locals.tf
@@ -4,7 +4,7 @@ locals {
     resources        = var.cluster_encryption_config_resources
     provider_key_arn = var.enabled ? aws_kms_key.cluster[0].arn : null
   }
-  aws_policy_prefix             = format("arn:%s:iam::aws:policy", data.aws_partition.current[0].partition)
+  aws_policy_prefix             = format("arn:%s:iam::aws:policy", data.aws_partition.current.partition)
   create_outposts_local_cluster = length(var.outpost_config) > 0
 
 }

--- a/main.tf
+++ b/main.tf
@@ -77,7 +77,7 @@ resource "aws_eks_cluster" "default" {
     }
   }
 
-  tags                      = merge(
+  tags = merge(
     module.labels.tags,
     var.eks_tags
   )

--- a/main.tf
+++ b/main.tf
@@ -21,7 +21,7 @@ resource "aws_cloudwatch_log_group" "default" {
   name              = "/aws/eks/${module.labels.id}/cluster"
   retention_in_days = var.cluster_log_retention_period
   tags              = module.labels.tags
-  kms_key_id        = join("", aws_kms_key.cloudwatch_log.*.arn)
+  kms_key_id        = aws_kms_key.cloudwatch_log[0].arn
 }
 
 #tfsec:ignore:aws-eks-no-public-cluster-access  ## To provide eks endpoint public access from local network
@@ -29,7 +29,7 @@ resource "aws_cloudwatch_log_group" "default" {
 resource "aws_eks_cluster" "default" {
   count                     = var.enabled ? 1 : 0
   name                      = module.labels.id
-  role_arn                  = join("", aws_iam_role.default.*.arn)
+  role_arn                  = aws_iam_role.default[0].arn
   version                   = var.kubernetes_version
   enabled_cluster_log_types = var.enabled_cluster_log_types
 
@@ -91,22 +91,22 @@ resource "aws_eks_cluster" "default" {
 
 data "tls_certificate" "cluster" {
   count = var.enabled && var.oidc_provider_enabled ? 1 : 0
-  url   = join("", aws_eks_cluster.default.*.identity.0.oidc.0.issuer)
+  url   = aws_eks_cluster.default[0].identity.0.oidc.0.issuer
 }
 
 resource "aws_iam_openid_connect_provider" "default" {
   count = var.enabled && var.oidc_provider_enabled ? 1 : 0
-  url   = join("", aws_eks_cluster.default.*.identity.0.oidc.0.issuer)
+  url   = aws_eks_cluster.default[0].identity.0.oidc.0.issuer
 
   client_id_list  = distinct(compact(concat(["sts.${data.aws_partition.current.dns_suffix}"], var.openid_connect_audiences)))
-  thumbprint_list = [join("", data.tls_certificate.cluster.*.certificates.0.sha1_fingerprint)]
+  thumbprint_list = [data.tls_certificate.cluster[0].certificates.0.sha1_fingerprint]
   tags            = module.labels.tags
 }
 
 resource "aws_eks_addon" "cluster" {
   for_each = var.enabled ? { for addon in var.addons : addon.addon_name => addon } : {}
 
-  cluster_name                = join("", aws_eks_cluster.default.*.name)
+  cluster_name                = aws_eks_cluster.default[0].name
   addon_name                  = each.key
   addon_version               = lookup(each.value, "addon_version", null)
   resolve_conflicts_on_create = lookup(each.value, "resolve_conflicts", null)

--- a/main.tf
+++ b/main.tf
@@ -32,8 +32,6 @@ resource "aws_eks_cluster" "default" {
   role_arn                  = join("", aws_iam_role.default.*.arn)
   version                   = var.kubernetes_version
   enabled_cluster_log_types = var.enabled_cluster_log_types
-  tags                      = module.labels.tags
-
 
   vpc_config {
     subnet_ids              = var.subnet_ids
@@ -79,11 +77,15 @@ resource "aws_eks_cluster" "default" {
     }
   }
 
+  tags                      = merge(
+    module.labels.tags,
+    var.eks_tags
+  )
+
   depends_on = [
     aws_iam_role_policy_attachment.amazon_eks_cluster_policy,
     aws_iam_role_policy_attachment.amazon_eks_service_policy,
     aws_cloudwatch_log_group.default,
-
   ]
 }
 

--- a/node_group/fargate_profile/fargate.tf
+++ b/node_group/fargate_profile/fargate.tf
@@ -28,7 +28,7 @@ resource "aws_iam_role" "fargate_role" {
   count = var.enabled && var.fargate_enabled ? 1 : 0
 
   name               = format("%s-fargate-role", module.labels.id)
-  assume_role_policy = join("", data.aws_iam_policy_document.aws_eks_fargate_policy.*.json)
+  assume_role_policy = data.aws_iam_policy_document.aws_eks_fargate_policy[0].json
   tags               = module.labels.tags
 }
 
@@ -36,7 +36,7 @@ resource "aws_iam_role_policy_attachment" "amazon_eks_fargate_pod_execution_role
   count = var.enabled && var.fargate_enabled ? 1 : 0
 
   policy_arn = "arn:aws:iam::aws:policy/AmazonEKSFargatePodExecutionRolePolicy"
-  role       = join("", aws_iam_role.fargate_role.*.name)
+  role       = aws_iam_role.fargate_role[0].name
 }
 
 #Module      : EKS Fargate

--- a/node_group/self_managed/main.tf
+++ b/node_group/self_managed/main.tf
@@ -58,10 +58,10 @@ resource "aws_launch_template" "this" {
   name  = module.labels.id
 
   ebs_optimized                        = var.ebs_optimized
-  image_id                             = join("", data.aws_ami.eks_default.*.image_id)
+  image_id                             = data.aws_ami.eks_default[0].image_id
   instance_type                        = var.instance_type
   key_name                             = var.key_name
-  user_data                            = base64encode(join("", data.template_file.userdata.*.rendered))
+  user_data                            = base64encode(data.template_file.userdata[0].rendered)
   disable_api_termination              = var.disable_api_termination
   instance_initiated_shutdown_behavior = var.instance_initiated_shutdown_behavior
   kernel_id                            = var.kernel_id
@@ -253,8 +253,8 @@ resource "aws_autoscaling_group" "this" {
     for_each = var.use_mixed_instances_policy ? [] : [1]
 
     content {
-      name    = join("", aws_launch_template.this.*.name)
-      version = join("", aws_launch_template.this.*.latest_version)
+      name    = aws_launch_template.this[0].name
+      version = aws_launch_template.this[0].latest_version
     }
   }
 
@@ -333,8 +333,8 @@ resource "aws_autoscaling_group" "this" {
 
       launch_template {
         launch_template_specification {
-          launch_template_name = join("", aws_launch_template.this.*.name)
-          version              = join("", aws_launch_template.this.*.latest_version)
+          launch_template_name = aws_launch_template.this[0].name
+          version              = aws_launch_template.this[0].latest_version
         }
 
         dynamic "override" {
@@ -392,7 +392,7 @@ resource "aws_autoscaling_schedule" "this" {
   for_each = var.enabled && var.create_schedule ? var.schedules : {}
 
   scheduled_action_name  = each.key
-  autoscaling_group_name = join("", aws_autoscaling_group.this.*.name)
+  autoscaling_group_name = aws_autoscaling_group.this[0].name
 
   min_size         = lookup(each.value, "min_size", null)
   max_size         = lookup(each.value, "max_size", null)

--- a/node_group/self_managed/variables.tf
+++ b/node_group/self_managed/variables.tf
@@ -109,7 +109,7 @@ variable "ebs_optimized" {
 
 variable "instance_type" {
   type        = string
-  default     = ""
+  default     = "t3.medium"
   description = "The type of the instance to launch"
 }
 

--- a/security_groups.tf
+++ b/security_groups.tf
@@ -21,7 +21,7 @@ resource "aws_security_group_rule" "node_group" {
   to_port           = 0
   protocol          = "-1"
   cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = join("", aws_security_group.node_group.*.id)
+  security_group_id = aws_security_group.node_group[0].id
   type              = "egress"
 }
 
@@ -34,8 +34,8 @@ resource "aws_security_group_rule" "ingress_self" {
   from_port                = 0
   to_port                  = 65535
   protocol                 = "-1"
-  security_group_id        = join("", aws_security_group.node_group.*.id)
-  source_security_group_id = join("", aws_security_group.node_group.*.id)
+  security_group_id        = aws_security_group.node_group[0].id
+  source_security_group_id = aws_security_group.node_group[0].id
   type                     = "ingress"
 }
 
@@ -49,7 +49,7 @@ resource "aws_security_group_rule" "ingress_security_groups_node_group" {
   to_port                  = 65535
   protocol                 = "-1"
   source_security_group_id = element(var.allowed_security_groups, count.index)
-  security_group_id        = join("", aws_security_group.node_group.*.id)
+  security_group_id        = aws_security_group.node_group[0].id
   type                     = "ingress"
 }
 
@@ -63,6 +63,6 @@ resource "aws_security_group_rule" "ingress_cidr_blocks_node_group" {
   to_port           = 0
   protocol          = "-1"
   cidr_blocks       = var.allowed_cidr_blocks
-  security_group_id = join("", aws_security_group.node_group.*.id)
+  security_group_id = aws_security_group.node_group[0].id
   type              = "ingress"
 }

--- a/self_node_groups.tf
+++ b/self_node_groups.tf
@@ -17,7 +17,7 @@ module "self_managed_node_group" {
 
   enabled = try(each.value.enabled, true)
 
-  cluster_name = join("", aws_eks_cluster.default.*.name)
+  cluster_name = aws_eks_cluster.default[0].name
   security_group_ids = compact(
     concat(
       aws_security_group.node_group.*.id,
@@ -25,7 +25,7 @@ module "self_managed_node_group" {
     )
   )
 
-  iam_instance_profile_arn = join("", aws_iam_instance_profile.default.*.arn)
+  iam_instance_profile_arn = aws_iam_instance_profile.default[0].arn
 
   # Autoscaling Group
   name        = try(each.value.name, each.key)

--- a/variables.tf
+++ b/variables.tf
@@ -42,6 +42,11 @@ variable "tags" {
   description = "Additional tags (e.g. map(`BusinessUnit`,`XYZ`)."
 }
 
+variable "eks_tags" {
+  type        = map(any)
+  default     = {}
+  description = "Additional tags for EKS Cluster only."
+}
 
 variable "enabled" {
   type        = bool


### PR DESCRIPTION
## what
* Update name of data for kubernetes cluster authentication.
* Add extra tags for kubernetes cluster if required.

## why
* There is no option to only attach particular tag to EKS Cluster only, so added that option.
* Change dynamic eks cluster name for data blocks with user passed name to simplify Kubernetes authentication.

## references
* Thanks @nikitadugar ma'am and @d4kverma sir 😃
