### PR TITLE
bug: aws-auth-config-fixed

### DIFF
--- a/aws_auth.tf
+++ b/aws_auth.tf
@@ -29,7 +29,7 @@
 
 
 locals {
-  certificate_authority_data_list          = coalescelist(aws_eks_cluster.default.[*].certificate_authority, [[{ data : "" }]])
+  certificate_authority_data_list          = coalescelist(aws_eks_cluster.default[*].certificate_authority, [[{ data : "" }]])
   certificate_authority_data_map           = local.certificate_authority_data_list_internal[0]
   certificate_authority_data               = local.certificate_authority_data_map["data"]
 

--- a/aws_auth.tf
+++ b/aws_auth.tf
@@ -88,9 +88,9 @@ data "aws_eks_cluster_auth" "eks" {
 }
 
 provider "kubernetes" {
-  token                  = data.aws_eks_cluster_auth.eks[0].token
-  host                   = data.aws_eks_cluster.eks[0].endpoint
-  cluster_ca_certificate = base64decode(data.aws_eks_cluster.eks[0].certificate_authority.0.data)
+  token                  = var.apply_config_map_aws_auth ? data.aws_eks_cluster_auth.eks[0].token : ""
+  host                   = var.apply_config_map_aws_auth ? data.aws_eks_cluster.eks[0].endpoint : ""
+  cluster_ca_certificate = var.apply_config_map_aws_auth ? base64decode(data.aws_eks_cluster.eks[0].certificate_authority[0].data) : ""
 }
 
 resource "kubernetes_config_map" "aws_auth_ignore_changes" {

--- a/aws_auth.tf
+++ b/aws_auth.tf
@@ -29,7 +29,7 @@
 
 
 locals {
-  certificate_authority_data_list          = coalescelist([for cert in aws_eks_cluster.default : cert.certificate_authority], [{ data : "" }])`  certificate_authority_data_list_internal = local.certificate_authority_data_list[0]
+  certificate_authority_data_list          = coalescelist(aws_eks_cluster.default.[*].certificate_authority, [[{ data : "" }]])
   certificate_authority_data_map           = local.certificate_authority_data_list_internal[0]
   certificate_authority_data               = local.certificate_authority_data_map["data"]
 
@@ -37,7 +37,7 @@ locals {
   # Note that we don't need to do this for managed Node Groups since EKS adds their roles to the ConfigMap automatically
   map_worker_roles = [
     {
-      rolearn : aws_iam_role.node_groups.[0].arn
+      rolearn : aws_iam_role.node_groups[0].arn
       username : "system:node:{{EC2PrivateDNSName}}"
       groups : [
         "system:bootstrappers",

--- a/aws_auth.tf
+++ b/aws_auth.tf
@@ -29,8 +29,7 @@
 
 
 locals {
-  certificate_authority_data_list          = coalescelist(aws_eks_cluster.default.*.certificate_authority, [[{ data : "" }]])
-  certificate_authority_data_list_internal = local.certificate_authority_data_list[0]
+  certificate_authority_data_list          = coalescelist([for cert in aws_eks_cluster.default : cert.certificate_authority], [{ data : "" }])`  certificate_authority_data_list_internal = local.certificate_authority_data_list[0]
   certificate_authority_data_map           = local.certificate_authority_data_list_internal[0]
   certificate_authority_data               = local.certificate_authority_data_map["data"]
 
@@ -38,7 +37,7 @@ locals {
   # Note that we don't need to do this for managed Node Groups since EKS adds their roles to the ConfigMap automatically
   map_worker_roles = [
     {
-      rolearn : aws_iam_role.node_groups.0.arn
+      rolearn : aws_iam_role.node_groups.[0].arn
       username : "system:node:{{EC2PrivateDNSName}}"
       groups : [
         "system:bootstrappers",

--- a/aws_auth.tf
+++ b/aws_auth.tf
@@ -32,6 +32,8 @@ locals {
   certificate_authority_data_list          = coalescelist(aws_eks_cluster.default[*].certificate_authority, [[{ data : "" }]])
   certificate_authority_data_map           = local.certificate_authority_data_list_internal[0]
   certificate_authority_data               = local.certificate_authority_data_map["data"]
+  certificate_authority_data_list_internal = local.certificate_authority_data_list[0]
+
 
   # Add worker nodes role ARNs (could be from many un-managed worker groups) to the ConfigMap
   # Note that we don't need to do this for managed Node Groups since EKS adds their roles to the ConfigMap automatically

--- a/aws_node_groups.tf
+++ b/aws_node_groups.tf
@@ -9,8 +9,8 @@ module "eks_managed_node_group" {
   cluster_version = var.kubernetes_version
   vpc_security_group_ids = compact(
     concat(
-      aws_security_group.node_group.[*].id,
-      aws_eks_cluster.default.[*].vpc_config.0.cluster_security_group_id,
+      aws_security_group.node_group[*].id,
+      aws_eks_cluster.default[*].vpc_config.0.cluster_security_group_id,
       var.nodes_additional_security_group_ids
 
     )

--- a/aws_node_groups.tf
+++ b/aws_node_groups.tf
@@ -9,8 +9,8 @@ module "eks_managed_node_group" {
   cluster_version = var.kubernetes_version
   vpc_security_group_ids = compact(
     concat(
-      aws_security_group.node_group.*.id,
-      aws_eks_cluster.default.*.vpc_config.0.cluster_security_group_id,
+      aws_security_group.node_group.[*].id,
+      aws_eks_cluster.default.[*].vpc_config.0.cluster_security_group_id,
       var.nodes_additional_security_group_ids
 
     )

--- a/aws_node_groups.tf
+++ b/aws_node_groups.tf
@@ -10,7 +10,7 @@ module "eks_managed_node_group" {
   vpc_security_group_ids = compact(
     concat(
       aws_security_group.node_group[*].id,
-      aws_eks_cluster.default[*].vpc_config.0.cluster_security_group_id,
+      aws_eks_cluster.default[*].vpc_config[0].cluster_security_group_id,
       var.nodes_additional_security_group_ids
 
     )

--- a/examples/aws_managed/example.tf
+++ b/examples/aws_managed/example.tf
@@ -54,8 +54,6 @@ module "subnets" {
   extra_private_tags = {
     "kubernetes.io/cluster/${module.eks.cluster_name}" = "owned"
     "kubernetes.io/role/internal-elb"                  = "1"
-
-    tags = locals.tags
   }
 
   public_inbound_acl_rules = [

--- a/examples/aws_managed/example.tf
+++ b/examples/aws_managed/example.tf
@@ -325,9 +325,9 @@ module "eks" {
     critical = {
       name           = "${module.eks.cluster_name}-critical"
       capacity_type  = "ON_DEMAND"
-      min_size       = 1
-      max_size       = 2
-      desired_size   = 2
+      min_size       = 0
+      max_size       = 1
+      desired_size   = 0
       instance_types = ["t3.medium"]
     }
 

--- a/examples/aws_managed/example.tf
+++ b/examples/aws_managed/example.tf
@@ -271,7 +271,7 @@ module "eks" {
   name        = local.name
   environment = local.environment
   label_order = local.label_order
-  tags = local.tags
+  tags        = local.tags
 
   # EKS
   kubernetes_version     = "1.27"
@@ -291,22 +291,22 @@ module "eks" {
     tags = {
       "kubernetes.io/cluster/${module.eks.cluster_name}" = "shared"
       "k8s.io/cluster/${module.eks.cluster_name}"        = "shared"
-    propagate_tags = [{
-      key                 = "aws-node-termination-handler/managed"
-      value               = true
-      propagate_at_launch = true
-      },
-      {
-        key                 = "autoscaling:ResourceTag/k8s.io/cluster-autoscaler/${module.eks.cluster_id}"
-        value               = "owned"
+      propagate_tags = [{
+        key                 = "aws-node-termination-handler/managed"
+        value               = true
         propagate_at_launch = true
+        },
+        {
+          key                 = "autoscaling:ResourceTag/k8s.io/cluster-autoscaler/${module.eks.cluster_id}"
+          value               = "owned"
+          propagate_at_launch = true
       }]
     }
     propagate_tags = [{
       key                 = "aws-node-termination-handler/managed"
       value               = true
       propagate_at_launch = true
-      }]
+    }]
     block_device_mappings = {
       xvda = {
         device_name = "/dev/xvda"

--- a/examples/aws_managed/example.tf
+++ b/examples/aws_managed/example.tf
@@ -54,7 +54,6 @@ module "subnets" {
   extra_private_tags = {
     "kubernetes.io/cluster/${module.eks.cluster_name}" = "owned"
     "kubernetes.io/role/internal-elb"                  = "1"
-
   tags = local.tags
   }
 

--- a/examples/aws_managed/example.tf
+++ b/examples/aws_managed/example.tf
@@ -54,6 +54,8 @@ module "subnets" {
   extra_private_tags = {
     "kubernetes.io/cluster/${module.eks.cluster_name}" = "owned"
     "kubernetes.io/role/internal-elb"                  = "1"
+
+    tags = locals.tags
   }
 
   public_inbound_acl_rules = [
@@ -279,7 +281,7 @@ module "eks" {
   vpc_id                            = module.vpc.vpc_id
   subnet_ids                        = module.subnets.private_subnet_id
   allowed_security_groups           = [module.ssh.security_group_id]
-  eks_additional_security_group_ids = ["${module.ssh.security_group_id}", "${module.http_https.security_group_id}"]
+  eks_additional_security_group_ids = module.ssh.security_group_id, module.http_https.security_group_id
   allowed_cidr_blocks               = [local.vpc_cidr_block]
 
   # AWS Managed Node Group

--- a/examples/aws_managed/example.tf
+++ b/examples/aws_managed/example.tf
@@ -54,7 +54,6 @@ module "subnets" {
   extra_private_tags = {
     "kubernetes.io/cluster/${module.eks.cluster_name}" = "owned"
     "kubernetes.io/role/internal-elb"                  = "1"
-  tags = local.tags
   }
 
   public_inbound_acl_rules = [
@@ -272,6 +271,7 @@ module "eks" {
   name        = local.name
   environment = local.environment
   label_order = local.label_order
+  tags = local.tags
 
   # EKS
   kubernetes_version     = "1.27"
@@ -291,7 +291,22 @@ module "eks" {
     tags = {
       "kubernetes.io/cluster/${module.eks.cluster_name}" = "shared"
       "k8s.io/cluster/${module.eks.cluster_name}"        = "shared"
+    propagate_tags = [{
+      key                 = "aws-node-termination-handler/managed"
+      value               = true
+      propagate_at_launch = true
+      },
+      {
+        key                 = "autoscaling:ResourceTag/k8s.io/cluster-autoscaler/${module.eks.cluster_id}"
+        value               = "owned"
+        propagate_at_launch = true
+      }]
     }
+    propagate_tags = [{
+      key                 = "aws-node-termination-handler/managed"
+      value               = true
+      propagate_at_launch = true
+      }]
     block_device_mappings = {
       xvda = {
         device_name = "/dev/xvda"

--- a/examples/aws_managed/example.tf
+++ b/examples/aws_managed/example.tf
@@ -281,7 +281,7 @@ module "eks" {
   vpc_id                            = module.vpc.vpc_id
   subnet_ids                        = module.subnets.private_subnet_id
   allowed_security_groups           = [module.ssh.security_group_id]
-  eks_additional_security_group_ids = module.ssh.security_group_id, module.http_https.security_group_id
+  eks_additional_security_group_ids = [module.ssh.security_group_id, module.http_https.security_group_id]
   allowed_cidr_blocks               = [local.vpc_cidr_block]
 
   # AWS Managed Node Group

--- a/examples/aws_managed/example.tf
+++ b/examples/aws_managed/example.tf
@@ -54,6 +54,8 @@ module "subnets" {
   extra_private_tags = {
     "kubernetes.io/cluster/${module.eks.cluster_name}" = "owned"
     "kubernetes.io/role/internal-elb"                  = "1"
+
+  tags = local.tags
   }
 
   public_inbound_acl_rules = [

--- a/examples/aws_managed/versions.tf
+++ b/examples/aws_managed/versions.tf
@@ -11,5 +11,16 @@ terraform {
       source  = "hashicorp/cloudinit"
       version = ">= 2.0"
     }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.33.0" # Specify the appropriate version
+    }
+    template = {
+      source  = "hashicorp/template"
+      version = ">= 2.2.0"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = ">= 3.0.0"
   }
 }

--- a/examples/aws_managed/versions.tf
+++ b/examples/aws_managed/versions.tf
@@ -22,5 +22,6 @@ terraform {
     null = {
       source  = "hashicorp/null"
       version = ">= 3.0.0"
+    }
   }
 }

--- a/examples/aws_managed_with_fargate/example.tf
+++ b/examples/aws_managed_with_fargate/example.tf
@@ -54,6 +54,7 @@ module "subnets" {
   extra_private_tags = {
     "kubernetes.io/cluster/${module.eks.cluster_name}" = "owned"
     "kubernetes.io/role/internal-elb"                  = "1"
+  tags = local.tags
   }
 
   public_inbound_acl_rules = [

--- a/examples/aws_managed_with_fargate/example.tf
+++ b/examples/aws_managed_with_fargate/example.tf
@@ -54,7 +54,6 @@ module "subnets" {
   extra_private_tags = {
     "kubernetes.io/cluster/${module.eks.cluster_name}" = "owned"
     "kubernetes.io/role/internal-elb"                  = "1"
-  tags = local.tags
   }
 
   public_inbound_acl_rules = [
@@ -273,6 +272,7 @@ module "eks" {
   name        = local.name
   environment = local.environment
   label_order = local.label_order
+  tags = local.tags
 
   # EKS
   kubernetes_version     = "1.27"

--- a/examples/aws_managed_with_fargate/example.tf
+++ b/examples/aws_managed_with_fargate/example.tf
@@ -272,7 +272,7 @@ module "eks" {
   name        = local.name
   environment = local.environment
   label_order = local.label_order
-  tags = local.tags
+  tags        = local.tags
 
   # EKS
   kubernetes_version     = "1.27"

--- a/examples/aws_managed_with_fargate/example.tf
+++ b/examples/aws_managed_with_fargate/example.tf
@@ -280,7 +280,7 @@ module "eks" {
   vpc_id                            = module.vpc.vpc_id
   subnet_ids                        = module.subnets.private_subnet_id
   allowed_security_groups           = [module.ssh.security_group_id]
-  eks_additional_security_group_ids = ["${module.ssh.security_group_id}", "${module.http_https.security_group_id}"]
+  eks_additional_security_group_ids = [module.ssh.security_group_id, module.http_https.security_group_id]
   allowed_cidr_blocks               = [local.vpc_cidr_block]
 
   # AWS Managed Node Group

--- a/examples/aws_managed_with_fargate/versions.tf
+++ b/examples/aws_managed_with_fargate/versions.tf
@@ -11,5 +11,16 @@ terraform {
       source  = "hashicorp/cloudinit"
       version = ">= 2.0"
     }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.33.0" # Specify the appropriate version
+    }
+    template = {
+      source  = "hashicorp/template"
+      version = ">= 2.2.0"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = ">= 3.0.0"
   }
 }

--- a/examples/aws_managed_with_fargate/versions.tf
+++ b/examples/aws_managed_with_fargate/versions.tf
@@ -22,5 +22,6 @@ terraform {
     null = {
       source  = "hashicorp/null"
       version = ">= 3.0.0"
+    }
   }
 }

--- a/examples/complete/example.tf
+++ b/examples/complete/example.tf
@@ -51,7 +51,6 @@ module "subnets" {
   extra_private_tags = {
     "kubernetes.io/cluster/${module.eks.cluster_name}" = "shared"
     "kubernetes.io/role/internal-elb"                  = "1"
-
   tags = local.tags
   }
 

--- a/examples/complete/example.tf
+++ b/examples/complete/example.tf
@@ -51,7 +51,6 @@ module "subnets" {
   extra_private_tags = {
     "kubernetes.io/cluster/${module.eks.cluster_name}" = "shared"
     "kubernetes.io/role/internal-elb"                  = "1"
-  tags = local.tags
   }
 
   public_inbound_acl_rules = [
@@ -269,6 +268,7 @@ module "eks" {
   name        = local.name
   environment = local.environment
   enabled     = true
+  tags = local.tags
 
   kubernetes_version      = "1.27"
   endpoint_private_access = true

--- a/examples/complete/example.tf
+++ b/examples/complete/example.tf
@@ -268,7 +268,7 @@ module "eks" {
   name        = local.name
   environment = local.environment
   enabled     = true
-  tags = local.tags
+  tags        = local.tags
 
   kubernetes_version      = "1.27"
   endpoint_private_access = true
@@ -278,7 +278,7 @@ module "eks" {
   vpc_id                            = module.vpc.vpc_id
   subnet_ids                        = module.subnets.private_subnet_id
   allowed_security_groups           = [module.ssh.security_group_id]
-  eks_additional_security_group_ids = [module.ssh.security_group_id,module.http_https.security_group_id]
+  eks_additional_security_group_ids = [module.ssh.security_group_id, module.http_https.security_group_id]
   allowed_cidr_blocks               = [local.vpc_cidr_block]
 
   # Self Managed Node Group

--- a/examples/complete/example.tf
+++ b/examples/complete/example.tf
@@ -51,6 +51,8 @@ module "subnets" {
   extra_private_tags = {
     "kubernetes.io/cluster/${module.eks.cluster_name}" = "shared"
     "kubernetes.io/role/internal-elb"                  = "1"
+
+  tags = local.tags
   }
 
   public_inbound_acl_rules = [

--- a/examples/complete/example.tf
+++ b/examples/complete/example.tf
@@ -277,7 +277,7 @@ module "eks" {
   vpc_id                            = module.vpc.vpc_id
   subnet_ids                        = module.subnets.private_subnet_id
   allowed_security_groups           = [module.ssh.security_group_id]
-  eks_additional_security_group_ids = ["${module.ssh.security_group_id}", "${module.http_https.security_group_id}"]
+  eks_additional_security_group_ids = [module.ssh.security_group_id,module.http_https.security_group_id]
   allowed_cidr_blocks               = [local.vpc_cidr_block]
 
   # Self Managed Node Group

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -11,5 +11,16 @@ terraform {
       source  = "hashicorp/cloudinit"
       version = ">= 2.0"
     }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.33.0" # Specify the appropriate version
+    }
+    template = {
+      source  = "hashicorp/template"
+      version = ">= 2.2.0"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = ">= 3.0.0"
   }
 }

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -22,5 +22,6 @@ terraform {
     null = {
       source  = "hashicorp/null"
       version = ">= 3.0.0"
+    }
   }
 }

--- a/examples/self_managed/example.tf
+++ b/examples/self_managed/example.tf
@@ -50,6 +50,7 @@ module "subnets" {
   extra_private_tags = {
     "kubernetes.io/cluster/${module.eks.cluster_name}" = "shared"
     "kubernetes.io/role/internal-elb"                  = "1"
+  tags = local.tags
   }
 
   public_inbound_acl_rules = [
@@ -237,7 +238,7 @@ module "eks" {
   vpc_id                            = module.vpc.vpc_id
   subnet_ids                        = module.subnets.private_subnet_id
   allowed_security_groups           = [module.ssh.security_group_id]
-  eks_additional_security_group_ids = ["${module.ssh.security_group_id}", "${module.http_https.security_group_id}"]
+  eks_additional_security_group_ids = [module.ssh.security_group_id , module.http_https.security_group_id]
   allowed_cidr_blocks               = [local.vpc_cidr_block]
 
   # Self Managed Node Grou

--- a/examples/self_managed/example.tf
+++ b/examples/self_managed/example.tf
@@ -1,6 +1,6 @@
 terraform {
   required_version = ">= 1.5.4"
-  }
+}
 provider "aws" {
   region = local.region
 }
@@ -232,9 +232,9 @@ module "eks" {
 
   name        = local.name
   environment = "test"
-  tags = local.tags
+  tags        = local.tags
 
-data "aws_caller_identity" "current" {}
+  data "aws_caller_identity" "current" {}
 
   # EKS
   kubernetes_version      = "1.27"
@@ -244,7 +244,7 @@ data "aws_caller_identity" "current" {}
   vpc_id                            = module.vpc.vpc_id
   subnet_ids                        = module.subnets.private_subnet_id
   allowed_security_groups           = [module.ssh.security_group_id]
-  eks_additional_security_group_ids = [module.ssh.security_group_id , module.http_https.security_group_id]
+  eks_additional_security_group_ids = [module.ssh.security_group_id, module.http_https.security_group_id]
   allowed_cidr_blocks               = [local.vpc_cidr_block]
 
   # Self Managed Node Grou
@@ -257,8 +257,8 @@ data "aws_caller_identity" "current" {}
       propagate_at_launch = true
       },
       {
-        key                 = "autoscaling:ResourceTag/k8s.io/cluster-autoscaler/${module.eks.cluster_id}"
-        value               = "owned"
+        key   = "autoscaling:ResourceTag/k8s.io/cluster-autoscaler/${module.eks.cluster_id}"
+        value = "owned"
       }
     ]
 

--- a/examples/self_managed/example.tf
+++ b/examples/self_managed/example.tf
@@ -1,9 +1,5 @@
 terraform {
   required_version = ">= 1.5.4"
-  kubernetes = {
-      source  = "hashicorp/kubernetes"
-      version = ">= 2.33.0" # Specify the appropriate version
-    }
   }
 provider "aws" {
   region = local.region
@@ -58,8 +54,6 @@ module "subnets" {
   extra_private_tags = {
     "kubernetes.io/cluster/${module.eks.cluster_name}" = "shared"
     "kubernetes.io/role/internal-elb"                  = "1"
-  tags = local.tags
-
   }
 
   public_inbound_acl_rules = [
@@ -238,6 +232,9 @@ module "eks" {
 
   name        = local.name
   environment = "test"
+  tags = local.tags
+
+data "aws_caller_identity" "current" {}
 
   # EKS
   kubernetes_version      = "1.27"
@@ -262,8 +259,6 @@ module "eks" {
       {
         key                 = "autoscaling:ResourceTag/k8s.io/cluster-autoscaler/${module.eks.cluster_id}"
         value               = "owned"
-        propagate_at_launch = true
-
       }
     ]
 

--- a/examples/self_managed/example.tf
+++ b/examples/self_managed/example.tf
@@ -1,11 +1,13 @@
-provider "aws" {
-  region = local.region
-  kubernetes {
+terraform {
+  required_version = ">= 1.5.4"
+  kubernetes = {
       source  = "hashicorp/kubernetes"
       version = ">= 2.33.0" # Specify the appropriate version
     }
+  }
+provider "aws" {
+  region = local.region
 }
-
 locals {
   name                  = "clouddrove-eks"
   region                = "eu-west-1"

--- a/examples/self_managed/example.tf
+++ b/examples/self_managed/example.tf
@@ -234,8 +234,6 @@ module "eks" {
   environment = "test"
   tags        = local.tags
 
-  
-
   # EKS
   kubernetes_version      = "1.27"
   endpoint_private_access = true

--- a/examples/self_managed/example.tf
+++ b/examples/self_managed/example.tf
@@ -1,6 +1,11 @@
 provider "aws" {
   region = local.region
+  kubernetes {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.33.0" # Specify the appropriate version
+    }
 }
+
 locals {
   name                  = "clouddrove-eks"
   region                = "eu-west-1"

--- a/examples/self_managed/example.tf
+++ b/examples/self_managed/example.tf
@@ -41,6 +41,7 @@ module "subnets" {
   ipv6_cidr_block     = module.vpc.ipv6_cidr_block
   type                = "public-private"
   igw_id              = module.vpc.igw_id
+  label_order         = local.label_order
 
   extra_public_tags = {
     "kubernetes.io/cluster/${module.eks.cluster_name}" = "shared"
@@ -51,6 +52,7 @@ module "subnets" {
     "kubernetes.io/cluster/${module.eks.cluster_name}" = "shared"
     "kubernetes.io/role/internal-elb"                  = "1"
   tags = local.tags
+
   }
 
   public_inbound_acl_rules = [

--- a/examples/self_managed/example.tf
+++ b/examples/self_managed/example.tf
@@ -234,7 +234,7 @@ module "eks" {
   environment = "test"
   tags        = local.tags
 
-  data "aws_caller_identity" "current" {}
+  
 
   # EKS
   kubernetes_version      = "1.27"

--- a/examples/self_managed/versions.tf
+++ b/examples/self_managed/versions.tf
@@ -10,5 +10,13 @@ terraform {
       source  = "hashicorp/cloudinit"
       version = ">= 2.0"
     }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.33.0" # Specify the appropriate version
+    }
+    template = {
+      source  = "hashicorp/template"
+      version = ">= 2.2.0"
+    }
   }
 }

--- a/locals.tf
+++ b/locals.tf
@@ -11,5 +11,5 @@ locals {
     count    = var.enabled ? 1 : 0
     filename = "${path.module}/kubeconfig_generated"
     content  = data.template_file.kubeconfig[0].rendered
-}
+  }
 }

--- a/locals.tf
+++ b/locals.tf
@@ -12,3 +12,4 @@ locals {
     filename = "${path.module}/kubeconfig_generated"
     content  = data.template_file.kubeconfig[0].rendered
 }
+}

--- a/locals.tf
+++ b/locals.tf
@@ -7,9 +7,4 @@ locals {
   aws_policy_prefix             = format("arn:%s:iam::aws:policy", data.aws_partition.current.partition)
   create_outposts_local_cluster = length(var.outpost_config) > 0
 
-  resource "local_file" "kubeconfig" {
-    count    = var.enabled ? 1 : 0
-    filename = "${path.module}/kubeconfig_generated"
-    content  = data.template_file.kubeconfig[0].rendered
-  }
 }

--- a/locals.tf
+++ b/locals.tf
@@ -7,4 +7,8 @@ locals {
   aws_policy_prefix             = format("arn:%s:iam::aws:policy", data.aws_partition.current.partition)
   create_outposts_local_cluster = length(var.outpost_config) > 0
 
+  resource "local_file" "kubeconfig" {
+    count    = var.enabled ? 1 : 0
+    filename = "${path.module}/kubeconfig_generated"
+    content  = data.template_file.kubeconfig[0].rendered
 }

--- a/main.tf
+++ b/main.tf
@@ -44,9 +44,9 @@ resource "aws_eks_cluster" "default" {
   dynamic "encryption_config" {
     for_each = var.cluster_encryption_config_enabled ? [local.cluster_encryption_config] : []
     content {
-      resources = lookup(encryption_config.value, "resources")
+      resources = lookup(encryption_config.value, "resources", null)
       provider {
-        key_arn = lookup(encryption_config.value, "provider_key_arn")
+        key_arn = lookup(encryption_config.value, "provider_key_arn", null)
       }
     }
   }

--- a/main.tf
+++ b/main.tf
@@ -38,8 +38,7 @@ resource "aws_eks_cluster" "default" {
     endpoint_private_access = var.endpoint_private_access
     endpoint_public_access  = var.endpoint_public_access
     public_access_cidrs     = var.public_access_cidrs
-    security_group_ids      = var.eks_additional_security_group_ids
-    vpc_security_group_ids  = var.vpc_security_group_ids
+    security_group_ids      = concat(var.eks_additional_security_group_ids, var.vpc_security_group_ids)
   }
 
   dynamic "encryption_config" {

--- a/main.tf
+++ b/main.tf
@@ -91,15 +91,15 @@ resource "aws_eks_cluster" "default" {
 
 data "tls_certificate" "cluster" {
   count = var.enabled && var.oidc_provider_enabled ? 1 : 0
-  url   = aws_eks_cluster.default[0].identity.0.oidc.0.issuer
+  url   = aws_eks_cluster.default[0].identity[0].oidc[0].issuer
 }
 
 resource "aws_iam_openid_connect_provider" "default" {
   count = var.enabled && var.oidc_provider_enabled ? 1 : 0
-  url   = aws_eks_cluster.default[0].identity.0.oidc.0.issuer
+  url   = aws_eks_cluster.default[0].identity[0].oidc[0].issuer
 
   client_id_list  = distinct(compact(concat(["sts.${data.aws_partition.current.dns_suffix}"], var.openid_connect_audiences)))
-  thumbprint_list = [data.tls_certificate.cluster[0].certificates.0.sha1_fingerprint]
+  thumbprint_list = [data.tls_certificate.cluster[0].certificates[0].sha1_fingerprint]
   tags            = module.labels.tags
 }
 

--- a/main.tf
+++ b/main.tf
@@ -39,6 +39,7 @@ resource "aws_eks_cluster" "default" {
     endpoint_public_access  = var.endpoint_public_access
     public_access_cidrs     = var.public_access_cidrs
     security_group_ids      = var.eks_additional_security_group_ids
+    vpc_security_group_ids  = var.vpc_security_group_ids
   }
 
   dynamic "encryption_config" {

--- a/node_group/aws_managed/main.tf
+++ b/node_group/aws_managed/main.tf
@@ -40,6 +40,7 @@ resource "aws_launch_template" "this" {
   disable_api_termination = var.disable_api_termination
   kernel_id               = var.kernel_id
   ram_disk_id             = var.ram_disk_id
+  default_version = var.launch_template_default_version 
 
   dynamic "block_device_mappings" {
     for_each = var.block_device_mappings

--- a/node_group/aws_managed/main.tf
+++ b/node_group/aws_managed/main.tf
@@ -26,13 +26,13 @@ resource "aws_launch_template" "this" {
   name        = module.labels.id
   description = var.launch_template_description
 
-  ebs_optimized           = var.ebs_optimized
-  image_id                = var.ami_id
+  ebs_optimized = var.ebs_optimized
+  image_id      = var.ami_id
   # # Set on node group instead
   # instance_type = var.launch_template_instance_type
-  key_name               = var.key_name
-  user_data              = var.before_cluster_joining_userdata
-  vpc_security_group_ids = var.vpc_security_group_ids
+  key_name                = var.key_name
+  user_data               = var.before_cluster_joining_userdata
+  vpc_security_group_ids  = var.vpc_security_group_ids
   disable_api_termination = var.disable_api_termination
   kernel_id               = var.kernel_id
   ram_disk_id             = var.ram_disk_id
@@ -45,7 +45,7 @@ resource "aws_launch_template" "this" {
 
   instance_market_options {
     market_type = var.instance_market_options.market_type
-    
+
     spot_options {
       max_price = var.instance_market_options.spot_options.max_price
     }

--- a/node_group/aws_managed/main.tf
+++ b/node_group/aws_managed/main.tf
@@ -1,6 +1,3 @@
-data "aws_partition" "current" {}
-
-data "aws_caller_identity" "current" {}
 
 #Module      : label
 #Description : Terraform module to create consistent naming for multiple names.
@@ -36,11 +33,12 @@ resource "aws_launch_template" "this" {
   key_name               = var.key_name
   user_data              = var.before_cluster_joining_userdata
   vpc_security_group_ids = var.vpc_security_group_ids
-
+  instance_market_options = var.instance_market_options
   disable_api_termination = var.disable_api_termination
   kernel_id               = var.kernel_id
   ram_disk_id             = var.ram_disk_id
   default_version = var.update_launch_template_default_version ? var.launch_template_default_version : null
+  launch_template_tags = var.launch_template_tags
 
 
   dynamic "block_device_mappings" {
@@ -246,7 +244,7 @@ resource "aws_eks_node_group" "this" {
     for_each = var.taints
     content {
       key    = taint.value.key
-      value  = lookup(taint.value, "value")
+      value  = lookup(taint.value, "value", null)
       effect = taint.value.effect
     }
   }

--- a/node_group/aws_managed/main.tf
+++ b/node_group/aws_managed/main.tf
@@ -22,18 +22,18 @@ module "labels" {
 
 
 resource "aws_launch_template" "this" {
-  count                    = var.enabled ? 1 : 0
-  name                     = module.labels.id
-  description              = var.launch_template_description
-  ebs_optimized            = var.ebs_optimized
-  image_id                 = var.ami_id
-  key_name                 = var.key_name
-  user_data                = var.before_cluster_joining_userdata
-  vpc_security_group_ids   = var.vpc_security_group_ids
-  disable_api_termination  = var.disable_api_termination
-  kernel_id                = var.kernel_id
-  ram_disk_id              = var.ram_disk_id
-  default_version          = var.update_launch_template_default_version ? var.launch_template_default_version : null
+  count                   = var.enabled ? 1 : 0
+  name                    = module.labels.id
+  description             = var.launch_template_description
+  ebs_optimized           = var.ebs_optimized
+  image_id                = var.ami_id
+  key_name                = var.key_name
+  user_data               = var.before_cluster_joining_userdata
+  vpc_security_group_ids  = var.vpc_security_group_ids
+  disable_api_termination = var.disable_api_termination
+  kernel_id               = var.kernel_id
+  ram_disk_id             = var.ram_disk_id
+  default_version         = var.update_launch_template_default_version ? var.launch_template_default_version : null
 
   dynamic "tag_specifications" {
     for_each = var.launch_template_tags != null ? [var.launch_template_tags] : []

--- a/node_group/aws_managed/main.tf
+++ b/node_group/aws_managed/main.tf
@@ -26,20 +26,30 @@ resource "aws_launch_template" "this" {
   name        = module.labels.id
   description = var.launch_template_description
 
-  ebs_optimized = var.ebs_optimized
-  image_id      = var.ami_id
+  ebs_optimized           = var.ebs_optimized
+  image_id                = var.ami_id
   # # Set on node group instead
   # instance_type = var.launch_template_instance_type
   key_name               = var.key_name
   user_data              = var.before_cluster_joining_userdata
   vpc_security_group_ids = var.vpc_security_group_ids
-  instance_market_options = var.instance_market_options
   disable_api_termination = var.disable_api_termination
   kernel_id               = var.kernel_id
   ram_disk_id             = var.ram_disk_id
-  default_version = var.update_launch_template_default_version ? var.launch_template_default_version : null
-  launch_template_tags = var.launch_template_tags
+  default_version         = var.update_launch_template_default_version ? var.launch_template_default_version : null
 
+  tag_specifications {
+    resource_type = "instance"
+    tags          = var.launch_template_tags
+  }
+
+  instance_market_options {
+    market_type = var.instance_market_options.market_type
+    
+    spot_options {
+      max_price = var.instance_market_options.spot_options.max_price
+    }
+  }
 
   dynamic "block_device_mappings" {
     for_each = var.block_device_mappings

--- a/node_group/aws_managed/main.tf
+++ b/node_group/aws_managed/main.tf
@@ -38,18 +38,25 @@ resource "aws_launch_template" "this" {
   ram_disk_id             = var.ram_disk_id
   default_version         = var.update_launch_template_default_version ? var.launch_template_default_version : null
 
-  tag_specifications {
-    resource_type = "instance"
-    tags          = var.launch_template_tags
-  }
 
-  instance_market_options {
-    market_type = var.instance_market_options.market_type
-
-    spot_options {
-      max_price = var.instance_market_options.spot_options.max_price
+  dynamic "tag_specifications" {
+    for_each = var.launch_template_tags != null ? [var.launch_template_tags] : []
+    content {
+      resource_type = "instance"
+      tags          = tag_specifications.value
     }
   }
+
+  # Dynamic block for instance_market_options
+  dynamic "instance_market_options" {
+    for_each = var.instance_market_options != null ? [var.instance_market_options] : []
+    content {}
+
+  dynamic "spot_options" {
+    for_each = instance_market_options.value.spot_options != null ? [instance_market_options.value.spot_options] : []
+    content {}
+      }
+    }
 
   dynamic "block_device_mappings" {
     for_each = var.block_device_mappings

--- a/node_group/aws_managed/main.tf
+++ b/node_group/aws_managed/main.tf
@@ -40,7 +40,8 @@ resource "aws_launch_template" "this" {
   disable_api_termination = var.disable_api_termination
   kernel_id               = var.kernel_id
   ram_disk_id             = var.ram_disk_id
-  default_version = var.launch_template_default_version 
+  default_version = var.update_launch_template_default_version ? var.launch_template_default_version : null
+
 
   dynamic "block_device_mappings" {
     for_each = var.block_device_mappings

--- a/node_group/aws_managed/main.tf
+++ b/node_group/aws_managed/main.tf
@@ -52,11 +52,13 @@ resource "aws_launch_template" "this" {
     for_each = var.instance_market_options != null ? [var.instance_market_options] : []
     content {}
 
-  dynamic "spot_options" {
-    for_each = instance_market_options.value.spot_options != null ? [instance_market_options.value.spot_options] : []
-    content {}
+      dynamic "spot_options" {
+        for_each = instance_market_options.value.spot_options != null ? [instance_market_options.value.spot_options] : []
+        content {
+          max_price = spot_options.value.max_price
+        }
       }
-    }
+  }
 
   dynamic "block_device_mappings" {
     for_each = var.block_device_mappings

--- a/node_group/aws_managed/main.tf
+++ b/node_group/aws_managed/main.tf
@@ -49,17 +49,20 @@ resource "aws_launch_template" "this" {
 
   # Dynamic block for instance_market_options
   dynamic "instance_market_options" {
-    for_each = var.instance_market_options != null ? [var.instance_market_options] : []
-    content {}
-
-      dynamic "spot_options" {
-        for_each = instance_market_options.value.spot_options != null ? [instance_market_options.value.spot_options] : []
-        content {
-          max_price = spot_options.value.max_price
-        }
-      }
+  for_each = var.instance_market_options != null ? [var.instance_market_options] : []
+  content {
+    market_type = instance_market_options.value.market_type
   }
 
+    # Dynamic block for spot_options within instance_market_options
+    dynamic "spot_options" {
+      for_each = instance_market_options.value.spot_options != null ? [instance_market_options.value.spot_options] : []
+      content {
+        max_price = spot_options.value.max_price
+      }
+    }
+  }
+  
   dynamic "block_device_mappings" {
     for_each = var.block_device_mappings
     content {

--- a/node_group/aws_managed/main.tf
+++ b/node_group/aws_managed/main.tf
@@ -22,22 +22,18 @@ module "labels" {
 
 
 resource "aws_launch_template" "this" {
-  count       = var.enabled ? 1 : 0
-  name        = module.labels.id
-  description = var.launch_template_description
-
-  ebs_optimized = var.ebs_optimized
-  image_id      = var.ami_id
-  # # Set on node group instead
-  # instance_type = var.launch_template_instance_type
-  key_name                = var.key_name
-  user_data               = var.before_cluster_joining_userdata
-  vpc_security_group_ids  = var.vpc_security_group_ids
-  disable_api_termination = var.disable_api_termination
-  kernel_id               = var.kernel_id
-  ram_disk_id             = var.ram_disk_id
-  default_version         = var.update_launch_template_default_version ? var.launch_template_default_version : null
-
+  count                    = var.enabled ? 1 : 0
+  name                     = module.labels.id
+  description              = var.launch_template_description
+  ebs_optimized            = var.ebs_optimized
+  image_id                 = var.ami_id
+  key_name                 = var.key_name
+  user_data                = var.before_cluster_joining_userdata
+  vpc_security_group_ids   = var.vpc_security_group_ids
+  disable_api_termination  = var.disable_api_termination
+  kernel_id                = var.kernel_id
+  ram_disk_id              = var.ram_disk_id
+  default_version          = var.update_launch_template_default_version ? var.launch_template_default_version : null
 
   dynamic "tag_specifications" {
     for_each = var.launch_template_tags != null ? [var.launch_template_tags] : []
@@ -48,12 +44,15 @@ resource "aws_launch_template" "this" {
   }
 
   dynamic "instance_market_options" {
-    for_each = var.instance_market_options != null ? [var.instance_market_options] : []
+    for_each = var.instance_market_options == true ? [{ market_type = "spot", spot_options = { max_price = "0.05" } }] : []
     content {
       market_type = instance_market_options.value.market_type
 
-      spot_options {
-        max_price = lookup(instance_market_options.value.spot_options, "max_price", null)
+      dynamic "spot_options" {
+        for_each = (instance_market_options.value.spot_options != null) ? [instance_market_options.value.spot_options] : []
+        content {
+          max_price = spot_options.value.max_price
+        }
       }
     }
   }

--- a/node_group/aws_managed/main.tf
+++ b/node_group/aws_managed/main.tf
@@ -47,22 +47,16 @@ resource "aws_launch_template" "this" {
     }
   }
 
-  # Dynamic block for instance_market_options
   dynamic "instance_market_options" {
-  for_each = var.instance_market_options != null ? [var.instance_market_options] : []
-  content {
-    market_type = instance_market_options.value.market_type
-  }
+    for_each = var.instance_market_options != null ? [var.instance_market_options] : []
+    content {
+      market_type = instance_market_options.value.market_type
 
-    # Dynamic block for spot_options within instance_market_options
-    dynamic "spot_options" {
-      for_each = instance_market_options.value.spot_options != null ? [instance_market_options.value.spot_options] : []
-      content {
-        max_price = spot_options.value.max_price
+      spot_options {
+        max_price = lookup(instance_market_options.value.spot_options, "max_price", null)
       }
     }
   }
-  
   dynamic "block_device_mappings" {
     for_each = var.block_device_mappings
     content {

--- a/node_group/aws_managed/variables.tf
+++ b/node_group/aws_managed/variables.tf
@@ -96,7 +96,7 @@ variable "launch_template_default_version" {
 variable "update_launch_template_default_version" {
   description = "Whether to update the launch templates default version on each update. Conflicts with `launch_template_default_version`"
   type        = bool
-  default     = true
+  default     = false
 }
 
 variable "disable_api_termination" {
@@ -162,7 +162,7 @@ variable "enclave_options" {
 variable "instance_market_options" {
   description = "The market (purchasing) option for the instance"
   type        = any
-  default     = null
+  default     = true
 }
 
 variable "license_specifications" {

--- a/node_group/fargate_profile/fargate.tf
+++ b/node_group/fargate_profile/fargate.tf
@@ -1,4 +1,5 @@
 terraform {
+  required_version = ">= 1.5.4"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/node_group/fargate_profile/fargate.tf
+++ b/node_group/fargate_profile/fargate.tf
@@ -20,7 +20,6 @@ module "labels" {
   delimiter   = var.delimiter
   attributes  = compact(concat(var.attributes, ["fargate"]))
   label_order = var.label_order
-  tags        = var.tags
 }
 
 

--- a/node_group/fargate_profile/fargate.tf
+++ b/node_group/fargate_profile/fargate.tf
@@ -49,7 +49,7 @@ resource "aws_eks_fargate_profile" "default" {
   fargate_profile_name   = format("%s-%s", module.labels.id, each.value.addon_name)
   pod_execution_role_arn = aws_iam_role.fargate_role[0].arn
   subnet_ids             = var.subnet_ids
-  tags                   = module.labels.tags
+  tags = var.tags
 
   selector {
     namespace = lookup(each.value, "namespace", "default")

--- a/node_group/fargate_profile/fargate.tf
+++ b/node_group/fargate_profile/fargate.tf
@@ -20,6 +20,7 @@ module "labels" {
   delimiter   = var.delimiter
   attributes  = compact(concat(var.attributes, ["fargate"]))
   label_order = var.label_order
+  tags        = var.tags
 }
 
 

--- a/node_group/fargate_profile/fargate.tf
+++ b/node_group/fargate_profile/fargate.tf
@@ -49,7 +49,7 @@ resource "aws_eks_fargate_profile" "default" {
   fargate_profile_name   = format("%s-%s", module.labels.id, each.value.addon_name)
   pod_execution_role_arn = aws_iam_role.fargate_role[0].arn
   subnet_ids             = var.subnet_ids
-  tags = var.tags
+  tags                   = var.tags
 
   selector {
     namespace = lookup(each.value, "namespace", "default")

--- a/node_group/fargate_profile/variables.tf
+++ b/node_group/fargate_profile/variables.tf
@@ -24,6 +24,12 @@ variable "attributes" {
   description = "Additional attributes (e.g. `1`)."
 }
 
+variable "tags" {
+  type        = map(any)
+  default     = {}
+  description = "Additional tags (e.g. map(`BusinessUnit`,`XYZ`)."
+}
+
 variable "managedby" {
   type        = string
   default     = "hello@clouddorve.com"

--- a/node_group/fargate_profile/variables.tf
+++ b/node_group/fargate_profile/variables.tf
@@ -24,12 +24,6 @@ variable "attributes" {
   description = "Additional attributes (e.g. `1`)."
 }
 
-variable "tags" {
-  type        = map(any)
-  default     = {}
-  description = "Additional tags (e.g. map(`BusinessUnit`,`XYZ`)."
-}
-
 variable "managedby" {
   type        = string
   default     = "hello@clouddorve.com"

--- a/node_group/self_managed/main.tf
+++ b/node_group/self_managed/main.tf
@@ -35,9 +35,9 @@ data "template_file" "userdata" {
     post_bootstrap_user_data   = var.post_bootstrap_user_data
     delete_timeout             = var.delete_timeout
     tags = flatten([for tag in var.propagate_tags : {
-    key   = tag["key"]
-    value = tag["value"]
-  }])
+      key   = tag["key"]
+      value = tag["value"]
+    }])
   }
 }
 #Module      : label

--- a/node_group/self_managed/main.tf
+++ b/node_group/self_managed/main.tf
@@ -383,7 +383,7 @@ resource "aws_autoscaling_group" "this" {
     for_each = merge(local.self_managed_node_group_default_tags, var.tags)
     content {
       key                 = tag.key
-      value               = tag.value
+      value               = ""
       propagate_at_launch = true
     }
   }

--- a/node_group/self_managed/main.tf
+++ b/node_group/self_managed/main.tf
@@ -35,8 +35,6 @@ data "template_file" "userdata" {
     post_bootstrap_user_data   = var.post_bootstrap_user_data
     delete_timeout             = var.delete_timeout
     propagate_tags             = var.propagate_tags
-
-
   }
 }
 #Module      : label

--- a/node_group/self_managed/main.tf
+++ b/node_group/self_managed/main.tf
@@ -7,10 +7,6 @@ locals {
   }
 }
 
-data "aws_partition" "current" {}
-
-data "aws_caller_identity" "current" {}
-
 
 #AMI AMAZON LINUX
 data "aws_ami" "eks_default" {
@@ -34,6 +30,12 @@ data "template_file" "userdata" {
     certificate_authority_data = var.cluster_auth_base64
     cluster_name               = var.cluster_name
     bootstrap_extra_args       = var.bootstrap_extra_args
+    cluster_service_ipv4_cidr  = var.cluster_service_ipv4_cidr
+    pre_bootstrap_user_data    = var.pre_bootstrap_user_data
+    post_bootstrap_user_data   = var.post_bootstrap_user_data
+    delete_timeout             = var.delete_timeout
+    propagate_tags             = var.propagate_tags
+
 
   }
 }

--- a/node_group/self_managed/main.tf
+++ b/node_group/self_managed/main.tf
@@ -34,7 +34,10 @@ data "template_file" "userdata" {
     pre_bootstrap_user_data    = var.pre_bootstrap_user_data
     post_bootstrap_user_data   = var.post_bootstrap_user_data
     delete_timeout             = var.delete_timeout
-    propagate_tags             = var.propagate_tags
+    tags = flatten([for tag in var.propagate_tags : {
+    key   = tag["key"]
+    value = tag["value"]
+  }])
   }
 }
 #Module      : label

--- a/node_group/self_managed/main.tf
+++ b/node_group/self_managed/main.tf
@@ -1,7 +1,7 @@
 locals {
   self_managed_node_group_default_tags = {
-    "Name"                                      = "${module.labels.id}"
-    "Environment"                               = "${var.environment}"
+    "Name"                                      = [module.labels.id]
+    "Environment"                               = [var.environment]
     "kubernetes.io/cluster/${var.cluster_name}" = "owned"
     "k8s.io/cluster/${var.cluster_name}"        = "owned"
   }

--- a/node_group/self_managed/versions.tf
+++ b/node_group/self_managed/versions.tf
@@ -15,13 +15,9 @@ terraform {
       source  = "hashicorp/template"
       version = ">= 2.2.0"
     }
-    null = {
-      source  = "hashicorp/null"
-      version = ">= 3.0.0"
-    }
     tls = {
-      source = "hashicorp/tls"
-      version = "~> 4.0" # Or specify the version you want to use
+      source  = "hashicorp/tls"
+      version = "~> 4.0"
     }
   }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -90,3 +90,8 @@ output "tags" {
 output "cluster_name" {
   value = module.labels.id
 }
+
+output "kubeconfig" {
+  description = "kubectl config file contents for this EKS cluster."
+  value       = data.template_file.kubeconfig
+}

--- a/self_node_groups.tf
+++ b/self_node_groups.tf
@@ -20,8 +20,8 @@ module "self_managed_node_group" {
   cluster_name = aws_eks_cluster.default[0].name
   security_group_ids = compact(
     concat(
-      aws_security_group.node_group.*.id,
-      aws_eks_cluster.default.*.vpc_config.0.cluster_security_group_id
+      aws_security_group.node_group.[*].id,
+      aws_eks_cluster.default.[*].vpc_config.0.cluster_security_group_id
     )
   )
 

--- a/self_node_groups.tf
+++ b/self_node_groups.tf
@@ -21,7 +21,7 @@ module "self_managed_node_group" {
   security_group_ids = compact(
     concat(
       aws_security_group.node_group[*].id,
-      aws_eks_cluster.default[*].vpc_config.0.cluster_security_group_id
+      aws_eks_cluster.default[*].vpc_config[0].cluster_security_group_id
     )
   )
 

--- a/self_node_groups.tf
+++ b/self_node_groups.tf
@@ -20,8 +20,8 @@ module "self_managed_node_group" {
   cluster_name = aws_eks_cluster.default[0].name
   security_group_ids = compact(
     concat(
-      aws_security_group.node_group.[*].id,
-      aws_eks_cluster.default.[*].vpc_config.0.cluster_security_group_id
+      aws_security_group.node_group[*].id,
+      aws_eks_cluster.default[*].vpc_config.0.cluster_security_group_id
     )
   )
 

--- a/variables.tf
+++ b/variables.tf
@@ -229,11 +229,11 @@ variable "endpoint_public_access" {
   description = "Indicates whether or not the Amazon EKS public API server endpoint is enabled. Default to AWS EKS resource and it is true."
 }
 
-#variable "vpc_security_group_ids" {
-#  type        = list(string)
-#  default     = []
-#  description = "A list of security group IDs to associate"
-#}
+variable "vpc_security_group_ids" {
+  type        = list(string)
+  default     = []
+  description = "A list of security group IDs to associate"
+}
 #-----------------------------------------------TimeOuts----------------------------------------------------------------
 
 variable "cluster_timeouts" {
@@ -319,12 +319,6 @@ variable "managed_node_group" {
 }
 
 #-----------------------------------------------ASG-Schedule----------------------------------------------------------------
-
-#variable "create_schedule" {
-#  description = "Determines whether to create autoscaling group schedule or not"
-#  type        = bool
-#  default     = true
-#}
 
 variable "schedules" {
   description = "Map of autoscaling group schedule to create"

--- a/variables.tf
+++ b/variables.tf
@@ -140,6 +140,16 @@ variable "outpost_config" {
   default     = {}
 }
 
+variable "instance_market_options" {
+  type = object({
+    market_type = string
+    spot_options = optional(object({
+      max_price = string
+    }))
+  })
+  default = null
+}
+
 #-----------------------------------------------------------KMS---------------------------------------------------------
 variable "cluster_encryption_config_enabled" {
   type        = bool

--- a/variables.tf
+++ b/variables.tf
@@ -229,11 +229,11 @@ variable "endpoint_public_access" {
   description = "Indicates whether or not the Amazon EKS public API server endpoint is enabled. Default to AWS EKS resource and it is true."
 }
 
-variable "vpc_security_group_ids" {
-  type        = list(string)
-  default     = []
-  description = "A list of security group IDs to associate"
-}
+#variable "vpc_security_group_ids" {
+#  type        = list(string)
+#  default     = []
+#  description = "A list of security group IDs to associate"
+#}
 #-----------------------------------------------TimeOuts----------------------------------------------------------------
 
 variable "cluster_timeouts" {
@@ -320,11 +320,11 @@ variable "managed_node_group" {
 
 #-----------------------------------------------ASG-Schedule----------------------------------------------------------------
 
-variable "create_schedule" {
-  description = "Determines whether to create autoscaling group schedule or not"
-  type        = bool
-  default     = true
-}
+#variable "create_schedule" {
+#  description = "Determines whether to create autoscaling group schedule or not"
+#  type        = bool
+#  default     = true
+#}
 
 variable "schedules" {
   description = "Map of autoscaling group schedule to create"

--- a/variables.tf
+++ b/variables.tf
@@ -140,16 +140,6 @@ variable "outpost_config" {
   default     = {}
 }
 
-variable "instance_market_options" {
-  type = object({
-    market_type = string
-    spot_options = optional(object({
-      max_price = string
-    }))
-  })
-  default = null
-}
-
 #-----------------------------------------------------------KMS---------------------------------------------------------
 variable "cluster_encryption_config_enabled" {
   type        = bool

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,6 @@
 terraform {
   required_version = ">= 1.5.4"
   kubernetes = ">= 2.33.0"
-  }
 
   required_providers {
     aws = {

--- a/versions.tf
+++ b/versions.tf
@@ -7,5 +7,9 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 5.11.0"
     }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.33.0" # Specify the appropriate version
+    }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -7,5 +7,17 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 5.11.0"
     }
+    template = {
+      source  = "hashicorp/template"
+      version = ">= 2.2.0" # Update to the minimum required version
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = ">= 3.2.3" # Update to the minimum required version
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.33.0" # Update to the minimum required version
+    }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -19,5 +19,9 @@ terraform {
       source  = "hashicorp/kubernetes"
       version = ">= 2.33.0" # Update to the minimum required version
     }
+    tls = {
+      source  = "hashicorp/tls"
+      version = ">= 4.0.6" # Specify the appropriate version
+    }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -11,5 +11,13 @@ terraform {
       source  = "hashicorp/kubernetes"
       version = ">= 2.33.0" # Specify the appropriate version
     }
+    template = {
+      source  = "hashicorp/template"
+      version = ">= 2.2.0"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = ">= 3.0.0"
+    }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,12 +1,15 @@
 # Terraform version
 terraform {
   required_version = ">= 1.5.4"
-  kubernetes = ">= 2.33.0"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
       version = ">= 5.11.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.33.0" # Specify the appropriate version
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -7,21 +7,5 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 5.11.0"
     }
-    template = {
-      source  = "hashicorp/template"
-      version = ">= 2.2.0" # Update to the minimum required version
-    }
-    null = {
-      source  = "hashicorp/null"
-      version = ">= 3.2.3" # Update to the minimum required version
-    }
-    kubernetes = {
-      source  = "hashicorp/kubernetes"
-      version = ">= 2.33.0" # Update to the minimum required version
-    }
-    tls = {
-      source  = "hashicorp/tls"
-      version = ">= 4.0.6" # Specify the appropriate version
-    }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -20,7 +20,7 @@ terraform {
       version = ">= 3.0.0"
     }
     tls = {
-      source = "hashicorp/tls"
+      source  = "hashicorp/tls"
       version = "~> 4.0" # Or specify the version you want to use
     }
   }

--- a/versions.tf
+++ b/versions.tf
@@ -1,15 +1,13 @@
 # Terraform version
 terraform {
   required_version = ">= 1.5.4"
+  kubernetes = ">= 2.33.0"
+  }
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
       version = ">= 5.11.0"
-    }
-    kubernetes = {
-      source  = "hashicorp/kubernetes"
-      version = ">= 2.33.0" # Specify the appropriate version
     }
   }
 }


### PR DESCRIPTION
## What
Using `apply_config_map_aws_auth = false` throws error mentioned below.
```bash
│ 
│   on ../../aws_auth.tf line 91, in provider "kubernetes":
│   91:   token                  = data.aws_eks_cluster_auth.eks[0].token
│     ├────────────────
│     │ data.aws_eks_cluster_auth.eks is empty tuple
│ 
│ The given key does not identify an element in this collection value: the collection has no elements.
╵
╷
│ Error: Invalid index
│ 
│   on ../../aws_auth.tf line 92, in provider "kubernetes":
│   92:   host                   = data.aws_eks_cluster.eks[0].endpoint
│     ├────────────────
│     │ data.aws_eks_cluster.eks is empty tuple
│ 
│ The given key does not identify an element in this collection value: the collection has no elements.
╵
╷
│ Error: Invalid index
│ 
│   on ../../aws_auth.tf line 93, in provider "kubernetes":
│   93:   cluster_ca_certificate = base64decode(data.aws_eks_cluster.eks[0].certificate_authority.0.data)
│     ├────────────────
│     │ data.aws_eks_cluster.eks is empty tuple
│ 
│ The given key does not identify an element in this collection value: the collection has no elements.

```

## Why
It should be optional to user if they want to manage `aws-auth` confimap manually or via terraform.