### PR TITLE
feat: custom NodeGroup names without environment prefix

### DIFF
--- a/aws_node_groups.tf
+++ b/aws_node_groups.tf
@@ -17,7 +17,7 @@ module "eks_managed_node_group" {
   )
   # EKS Managed Node Group
   name        = try(each.value.name, each.key)
-  environment = var.environment
+  environment = try(each.value.name != "" ? "" : var.environment, var.environment)
   repository  = var.repository
   subnet_ids  = try(each.value.subnet_ids, var.managed_node_group_defaults.subnet_ids, var.subnet_ids)
 

--- a/examples/aws_managed/example.tf
+++ b/examples/aws_managed/example.tf
@@ -273,7 +273,7 @@ module "eks" {
   label_order = local.label_order
 
   # EKS
-  kubernetes_version     = "1.27"
+  kubernetes_version     = "1.32"
   endpoint_public_access = true
   # Networking
   vpc_id                            = module.vpc.vpc_id

--- a/examples/aws_managed_with_fargate/example.tf
+++ b/examples/aws_managed_with_fargate/example.tf
@@ -274,7 +274,7 @@ module "eks" {
   label_order = local.label_order
 
   # EKS
-  kubernetes_version     = "1.27"
+  kubernetes_version     = "1.32"
   endpoint_public_access = true
   # Networking
   vpc_id                            = module.vpc.vpc_id

--- a/examples/complete/example.tf
+++ b/examples/complete/example.tf
@@ -269,7 +269,7 @@ module "eks" {
   environment = local.environment
   enabled     = true
 
-  kubernetes_version      = "1.27"
+  kubernetes_version      = "1.32"
   endpoint_private_access = true
   endpoint_public_access  = true
 

--- a/examples/self_managed/example.tf
+++ b/examples/self_managed/example.tf
@@ -230,7 +230,7 @@ module "eks" {
   environment = "test"
 
   # EKS
-  kubernetes_version      = "1.27"
+  kubernetes_version      = "1.32"
   endpoint_private_access = true
   endpoint_public_access  = true
   # Networking

--- a/variables.tf
+++ b/variables.tf
@@ -95,8 +95,8 @@ variable "nodes_additional_security_group_ids" {
   description = "EKS additional node group ids"
 }
 variable "addons" {
-  type = any
-  default = []
+  type        = any
+  default     = []
   description = "Manages [`aws_eks_addon`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_addon) resources."
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -96,23 +96,7 @@ variable "nodes_additional_security_group_ids" {
 }
 variable "addons" {
   type = any
-  default = [
-    {
-      addon_name        = "coredns"
-      addon_version     = "v1.10.1-eksbuild.2"
-      resolve_conflicts = "OVERWRITE"
-    },
-    {
-      addon_name        = "kube-proxy"
-      addon_version     = "v1.27.3-eksbuild.2"
-      resolve_conflicts = "OVERWRITE"
-    },
-    {
-      addon_name        = "vpc-cni"
-      addon_version     = "v1.13.4-eksbuild.1"
-      resolve_conflicts = "OVERWRITE"
-    },
-  ]
+  default = []
   description = "Manages [`aws_eks_addon`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_addon) resources."
 }
 


### PR DESCRIPTION
## What  
* Updated the `environment` variable assignment in the NodeGroups configuration to allow the use of a custom `NAME`.  
* Ensures that if `each.value.name` is not empty, it is used; otherwise, defaults to `var.environment`.  
* Provides a fallback mechanism using `try()` to prevent errors in case of misconfiguration.  
* Updated eks version from 1.27 to 1.32

## Why  
* Enables flexibility in naming NodeGroups without requiring the inclusion of a default environment name.  
* Ensures proper handling of cases where `each.value.name` is empty, preventing unexpected behavior.  
* Improves maintainability and clarity of the Terraform configuration.
  