### PR TITLE
fix:unauthorized error in aws_auth configmap for EKS

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -2,8 +2,7 @@ data "aws_partition" "current" {}
 data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 data "aws_eks_cluster" "eks_cluster" {
-  name   = try(aws_eks_cluster.default[0].name, var.cluster_name)
-  region = try(var.region, data.aws_region.current.region)
+  name = try(aws_eks_cluster.default[0].name, var.cluster_name)
 }
 data "aws_subnets" "eks" {
   count = var.external_cluster ? 1 : 0

--- a/examples/aws_managed/example.tf
+++ b/examples/aws_managed/example.tf
@@ -328,7 +328,7 @@ module "eks" {
     }
   }
 
-  apply_config_map_aws_auth = false
+  apply_config_map_aws_auth = true
   map_additional_iam_users = [
     {
       userarn  = "arn:aws:iam::123456789:user/hello@clouddrove.com"

--- a/examples/aws_managed/example.tf
+++ b/examples/aws_managed/example.tf
@@ -345,7 +345,7 @@ data "aws_eks_cluster" "this" {
 
 data "aws_eks_cluster_auth" "this" {
   depends_on = [module.eks]
-  name       = module.eks.cluster_certificate_authority_data
+  name       = module.eks.cluster_id
 }
 
 provider "kubernetes" {

--- a/examples/aws_managed/output.tf
+++ b/examples/aws_managed/output.tf
@@ -1,0 +1,33 @@
+################################################################################
+# Cluster
+################################################################################
+
+output "cluster_arn" {
+  description = "The Amazon Resource Name (ARN) of the cluster"
+  value       = module.eks.cluster_arn
+}
+
+output "cluster_endpoint" {
+  description = "Endpoint for your Kubernetes API server"
+  value       = module.eks.cluster_endpoint
+}
+
+output "cluster_id" {
+  description = "The ID of the EKS cluster. Note: currently a value is returned only for local EKS clusters created on Outposts"
+  value       = module.eks.cluster_id
+}
+
+output "cluster_name" {
+  description = "The name of the EKS cluster"
+  value       = module.eks.cluster_name
+}
+
+output "cluster_iam_role" {
+  description = "ARN of cluster IAM role"
+  value       = module.eks.cluster_iam_role_name
+}
+
+output "node_group_iam_role" {
+  description = "ARN of node group IAM role"
+  value       = module.eks.node_group_iam_role_name
+}

--- a/examples/eks-auto-mode/main.tf
+++ b/examples/eks-auto-mode/main.tf
@@ -123,8 +123,9 @@ module "eks" {
     enabled    = true
     node_pools = ["general-purpose"]
   }
-
+  create                                   = true
   enable_cluster_creator_admin_permissions = true
+  authentication_mode                      = "API_AND_CONFIG_MAP"
 
   vpc_id                            = module.vpc.vpc_id
   subnet_ids                        = module.subnets.private_subnet_id

--- a/examples/eks-nodegroup-with-existing-cluster/example.tf
+++ b/examples/eks-nodegroup-with-existing-cluster/example.tf
@@ -27,8 +27,7 @@ provider "kubernetes" {
 
 # Fetch existing EKS cluster
 data "aws_eks_cluster" "this" {
-  name   = local.eks_cluster_name
-  region = local.region
+  name = local.eks_cluster_name
 }
 
 # Fetch authentication token for the EKS cluster

--- a/main.tf
+++ b/main.tf
@@ -35,7 +35,7 @@ resource "aws_eks_cluster" "default" {
 
   access_config {
     authentication_mode                         = var.authentication_mode
-    bootstrap_cluster_creator_admin_permissions = false
+    bootstrap_cluster_creator_admin_permissions = var.enable_cluster_creator_admin_permissions
   }
   vpc_config {
     subnet_ids              = var.subnet_ids

--- a/variables.tf
+++ b/variables.tf
@@ -374,7 +374,7 @@ variable "bootstrap_self_managed_addons" {
 variable "authentication_mode" {
   description = "The authentication mode for the cluster. Valid values are `CONFIG_MAP`, `API` or `API_AND_CONFIG_MAP`"
   type        = string
-  default     = "API_AND_CONFIG_MAP"
+  default     = "CONFIG_MAP"
 }
 variable "cluster_compute_config" {
   description = "Configuration block for the cluster compute configuration"
@@ -411,13 +411,13 @@ variable "access_entries" {
 variable "enable_cluster_creator_admin_permissions" {
   description = "Indicates whether or not to add the cluster creator (the identity used by Terraform) as an administrator via access entry"
   type        = bool
-  default     = false
+  default     = true
 }
 
 variable "create" {
   description = "Controls if resources should be created (affects nearly all resources)"
   type        = bool
-  default     = true
+  default     = false
 }
 
 variable "create_node_iam_role" {


### PR DESCRIPTION
## what
* Changed the variable `authentication_mode` value form `"API_AND_CONFIG_MAP"` to `"CONFIG_MAP"`
*  Changed the variable `bootstrap_cluster_creator_admin_permissions` value form `"false"` to `"var.enable_cluster_creator_admin_permissions"`  to fix `Error: Unauthorized`

* Removed [template_file](https://github.com/clouddrove/terraform-aws-eks/blob/b00656be40908773e3d800b961abc64179feb7a8/node_group/self_managed/main.tf#L28-L39) and replaced it with [templatefile](https://github.com/terraform-aws-modules/terraform-aws-eks/blob/30664d261760ec97c670f90df3c793431cb096fb/modules/_user_data/main.tf#L50-L78) to fix `Error: Incompatible provider version`
## why

* To fix the below Error's
   * ```bash
      │ Error: Unauthorized
      │ 
      │   with module.eks.kubernetes_config_map.aws_auth_ignore_changes[0],
      │   on .terraform/modules/eks/aws_auth.tf line 64, in resource "kubernetes_config_map" "aws_auth_ignore_changes":
      │   64: resource "kubernetes_config_map" "aws_auth_ignore_changes" {
      │ 
      ```
   * ```bash
      │ Error: Incompatible provider version
      │ 
      │ Provider registry.terraform.io/hashicorp/template v2.2.0 does not have a package available for your current platform,
      │ darwin_arm64.
      │ 
      │ Provider releases are separate from Terraform CLI releases, so not all providers are available for all platforms. Other
      │ versions of this provider may have different platforms supported. 
      ```
