### PR TITLE
feat: update example to use clusterrole and clusterrolebinding for scoped eks access

### DIFF
--- a/examples/aws_managed/example.tf
+++ b/examples/aws_managed/example.tf
@@ -3,7 +3,7 @@ provider "aws" {
 }
 
 locals {
-  name                  = "cd-eks-testing"
+  name                  = "clouddrove-eks"
   region                = "us-east-1"
   vpc_cidr_block        = module.vpc.vpc_cidr_block
   additional_cidr_block = "172.16.0.0/16"

--- a/examples/aws_managed/example.tf
+++ b/examples/aws_managed/example.tf
@@ -16,7 +16,7 @@ provider "kubectl" {
 }
 
 locals {
-  name                  = "clouddrove-eks-testing"
+  name                  = "clouddrove-eks"
   region                = "us-east-1"
   vpc_cidr_block        = module.vpc.vpc_cidr_block
   additional_cidr_block = "172.16.0.0/16"

--- a/examples/aws_managed/example.tf
+++ b/examples/aws_managed/example.tf
@@ -331,15 +331,15 @@ module "eks" {
   apply_config_map_aws_auth = true
   map_additional_iam_users = [
     {
-      userarn: "arn:aws:iam::924144197303:role/AWSReservedSSO_RestrictedAdmin_58b12189d22677ff"
-      username = "pranay.deokar@clouddrove.com"
+      userarn: "arn:aws:iam::123456789:role/AWSReservedSSO_RestrictedAdmin_xxxxxxxxxxx"
+      username = "hello@clouddrove.com"
       groups   = ["system:masters"]
     }
   ]
 
   map_additional_iam_roles = [
     {
-      rolearn  = "arn:aws:iam::924144197303:role/AWSReservedSSO_ReadOnlyAccess_e5aa35a0cd28fa16"
+      rolearn  = "arn:aws:iam::123456789:role/AWSReservedSSO_ReadOnlyAccess_xxxxxxxx"
       username = "readonly"
       groups   = ["view"]
     }

--- a/examples/aws_managed/example.tf
+++ b/examples/aws_managed/example.tf
@@ -331,7 +331,7 @@ module "eks" {
   apply_config_map_aws_auth = true
   map_additional_iam_users = [
     {
-      userarn: "arn:aws:iam::123456789:user/hello@clouddrove.com"
+      userarn  = "arn:aws:iam::123456789:user/hello@clouddrove.com"
       username = "hello@clouddrove.com"
       groups   = ["system:masters"]
     }

--- a/examples/aws_managed/example.tf
+++ b/examples/aws_managed/example.tf
@@ -331,7 +331,7 @@ module "eks" {
   apply_config_map_aws_auth = true
   map_additional_iam_users = [
     {
-      userarn: "arn:aws:iam::123456789:role/AWSReservedSSO_RestrictedAdmin_xxxxxxxxxxx"
+      userarn: "arn:aws:iam::123456789:user/hello@clouddrove.com"
       username = "hello@clouddrove.com"
       groups   = ["system:masters"]
     }

--- a/examples/aws_managed/example.tf
+++ b/examples/aws_managed/example.tf
@@ -2,8 +2,21 @@ provider "aws" {
   region = local.region
 }
 
+provider "kubernetes" {
+  host                   = data.aws_eks_cluster.this.endpoint
+  cluster_ca_certificate = base64decode(data.aws_eks_cluster.this.certificate_authority[0].data)
+  token                  = data.aws_eks_cluster_auth.this.token
+}
+
+provider "kubectl" {
+  host                   = data.aws_eks_cluster.this.endpoint
+  cluster_ca_certificate = base64decode(data.aws_eks_cluster.this.certificate_authority[0].data)
+  token                  = data.aws_eks_cluster_auth.this.token
+  load_config_file       = false
+}
+
 locals {
-  name                  = "clouddrove-eks"
+  name                  = "clouddrove-eks-testing"
   region                = "us-east-1"
   vpc_cidr_block        = module.vpc.vpc_cidr_block
   additional_cidr_block = "172.16.0.0/16"
@@ -12,6 +25,13 @@ locals {
   tags = {
     "kubernetes.io/cluster/${module.eks.cluster_name}" = "owned"
   }
+  kubectl_cluster_role_yaml_files = [
+    "${path.module}/yamls/ClusterRole-ReadWrite.yaml",
+    "${path.module}/yamls/ClusterRoleBinding-View.yaml",
+    "${path.module}/yamls/RoleBinding-View-Namespace.yaml",
+    "${path.module}/yamls/ClusterRoleBinding-ReadWrite.yaml",
+    "${path.module}/yamls/RoleBinding-ReadWrite-Namespace.yaml",
+  ]
 }
 
 ################################################################################
@@ -346,12 +366,6 @@ module "eks" {
   ]
 }
 
-locals {
-  kubectl_yaml_files = [
-    "${path.module}/yamls/ClusterRoleBinding-View.yaml",
-  ]
-}
-
 ## Kubernetes provider configuration
 data "aws_eks_cluster" "this" {
   depends_on = [module.eks]
@@ -363,21 +377,8 @@ data "aws_eks_cluster_auth" "this" {
   name       = module.eks.cluster_id
 }
 
-provider "kubernetes" {
-  host                   = data.aws_eks_cluster.this.endpoint
-  cluster_ca_certificate = base64decode(data.aws_eks_cluster.this.certificate_authority[0].data)
-  token                  = data.aws_eks_cluster_auth.this.token
-}
-
-provider "kubectl" {
-  host                   = data.aws_eks_cluster.this.endpoint
-  cluster_ca_certificate = base64decode(data.aws_eks_cluster.this.certificate_authority[0].data)
-  token                  = data.aws_eks_cluster_auth.this.token
-  load_config_file       = false
-}
-
-resource "kubectl_manifest" "apply" {
-  for_each = toset(local.kubectl_yaml_files)
+resource "kubectl_manifest" "cluster_roles" {
+  for_each = toset(local.kubectl_cluster_role_yaml_files)
   yaml_body = file(each.value)
   depends_on = [
     module.eks,

--- a/examples/aws_managed/example.tf
+++ b/examples/aws_managed/example.tf
@@ -1,3 +1,6 @@
+##--------------------------------------------------------------------------------
+## PROVIDERS
+##--------------------------------------------------------------------------------
 provider "aws" {
   region = local.region
 }
@@ -15,6 +18,22 @@ provider "kubectl" {
   load_config_file       = false
 }
 
+##--------------------------------------------------------------------------------
+## DATA SOURCES
+##--------------------------------------------------------------------------------
+data "aws_eks_cluster" "this" {
+  depends_on = [module.eks]
+  name       = module.eks.cluster_id
+}
+
+data "aws_eks_cluster_auth" "this" {
+  depends_on = [module.eks]
+  name       = module.eks.cluster_id
+}
+
+##--------------------------------------------------------------------------------
+## LOCALS
+##--------------------------------------------------------------------------------
 locals {
   name                  = "clouddrove-eks"
   region                = "us-east-1"
@@ -34,9 +53,9 @@ locals {
   ]
 }
 
-################################################################################
-# VPC module call
-################################################################################
+##--------------------------------------------------------------------------------
+## VPC module call
+##--------------------------------------------------------------------------------
 module "vpc" {
   source  = "clouddrove/vpc/aws"
   version = "2.0.0"
@@ -46,9 +65,9 @@ module "vpc" {
   cidr_block  = "10.10.0.0/16"
 }
 
-# ################################################################################
-# # Subnets moudle call
-# ################################################################################
+##--------------------------------------------------------------------------------
+## Subnets moudle call
+##--------------------------------------------------------------------------------
 
 module "subnets" {
   source  = "clouddrove/subnet/aws"
@@ -153,9 +172,9 @@ module "subnets" {
   ]
 }
 
-# ################################################################################
-# Security Groups module call
-################################################################################
+##--------------------------------------------------------------------------------
+## Security Groups module call
+##--------------------------------------------------------------------------------
 
 module "ssh" {
   source  = "clouddrove/security-group/aws"
@@ -249,9 +268,9 @@ module "http_https" {
   ]
 }
 
-################################################################################
-# KMS Module call
-################################################################################
+##--------------------------------------------------------------------------------
+## KMS Module call
+##--------------------------------------------------------------------------------
 module "kms" {
   source  = "clouddrove/kms/aws"
   version = "1.3.0"
@@ -281,9 +300,9 @@ data "aws_iam_policy_document" "kms" {
 
 data "aws_caller_identity" "current" {}
 
-################################################################################
-# EKS Module call
-################################################################################
+##--------------------------------------------------------------------------------
+## EKS Module call
+##--------------------------------------------------------------------------------
 module "eks" {
   source  = "../.."
   enabled = true
@@ -357,6 +376,7 @@ module "eks" {
     }
   ]
 
+  # -- This mapping requires yamls/ClusterRoleBinding-View.yaml to be applied on EKS Cluster
   map_additional_iam_roles = [
     {
       rolearn  = "arn:aws:iam::123456789:role/AWSReservedSSO_ReadOnlyAccess_xxxxxxxx"
@@ -366,19 +386,9 @@ module "eks" {
   ]
 }
 
-## Kubernetes provider configuration
-data "aws_eks_cluster" "this" {
-  depends_on = [module.eks]
-  name       = module.eks.cluster_id
-}
-
-data "aws_eks_cluster_auth" "this" {
-  depends_on = [module.eks]
-  name       = module.eks.cluster_id
-}
-
+# -- Applying yamls/*.yaml to the EKS Cluster
 resource "kubectl_manifest" "cluster_roles" {
-  for_each = toset(local.kubectl_cluster_role_yaml_files)
+  for_each  = toset(local.kubectl_cluster_role_yaml_files)
   yaml_body = file(each.value)
   depends_on = [
     module.eks,

--- a/examples/aws_managed/example.tf
+++ b/examples/aws_managed/example.tf
@@ -3,7 +3,7 @@ provider "aws" {
 }
 
 locals {
-  name                  = "clouddrove-eks"
+  name                  = "cd-eks-testing"
   region                = "us-east-1"
   vpc_cidr_block        = module.vpc.vpc_cidr_block
   additional_cidr_block = "172.16.0.0/16"
@@ -331,12 +331,27 @@ module "eks" {
   apply_config_map_aws_auth = true
   map_additional_iam_users = [
     {
-      userarn  = "arn:aws:iam::123456789:user/hello@clouddrove.com"
-      username = "hello@clouddrove.com"
+      userarn: "arn:aws:iam::924144197303:role/AWSReservedSSO_RestrictedAdmin_58b12189d22677ff"
+      username = "pranay.deokar@clouddrove.com"
       groups   = ["system:masters"]
     }
   ]
+
+  map_additional_iam_roles = [
+    {
+      rolearn  = "arn:aws:iam::924144197303:role/AWSReservedSSO_ReadOnlyAccess_e5aa35a0cd28fa16"
+      username = "readonly"
+      groups   = ["view"]
+    }
+  ]
 }
+
+locals {
+  kubectl_yaml_files = [
+    "${path.module}/yamls/ClusterRoleBinding-View.yaml",
+  ]
+}
+
 ## Kubernetes provider configuration
 data "aws_eks_cluster" "this" {
   depends_on = [module.eks]
@@ -352,4 +367,21 @@ provider "kubernetes" {
   host                   = data.aws_eks_cluster.this.endpoint
   cluster_ca_certificate = base64decode(data.aws_eks_cluster.this.certificate_authority[0].data)
   token                  = data.aws_eks_cluster_auth.this.token
+}
+
+provider "kubectl" {
+  host                   = data.aws_eks_cluster.this.endpoint
+  cluster_ca_certificate = base64decode(data.aws_eks_cluster.this.certificate_authority[0].data)
+  token                  = data.aws_eks_cluster_auth.this.token
+  load_config_file       = false
+}
+
+resource "kubectl_manifest" "apply" {
+  for_each = toset(local.kubectl_yaml_files)
+  yaml_body = file(each.value)
+  depends_on = [
+    module.eks,
+    data.aws_eks_cluster.this,
+    data.aws_eks_cluster_auth.this,
+  ]
 }

--- a/examples/aws_managed/versions.tf
+++ b/examples/aws_managed/versions.tf
@@ -9,7 +9,7 @@ terraform {
     }
     cloudinit = {
       source  = "hashicorp/cloudinit"
-      version = ">= 2.0"
+      version = ">= 5.80.0"
     }
     kubectl = {
       source  = "gavinbunney/kubectl"

--- a/examples/aws_managed/versions.tf
+++ b/examples/aws_managed/versions.tf
@@ -9,7 +9,11 @@ terraform {
     }
     cloudinit = {
       source  = "hashicorp/cloudinit"
-      version = ">= 5.80.0"
+      version = ">= 2.0"
+    }
+    kubectl = {
+      source  = "gavinbunney/kubectl"
+      version = ">= 1.19.0"
     }
   }
 }

--- a/examples/aws_managed/versions.tf
+++ b/examples/aws_managed/versions.tf
@@ -9,7 +9,7 @@ terraform {
     }
     cloudinit = {
       source  = "hashicorp/cloudinit"
-      version = ">= 5.80.0"
+      version = ">= 2.0.0"
     }
     kubectl = {
       source  = "gavinbunney/kubectl"

--- a/examples/aws_managed/yamls/ClusterRole-ReadWrite.yaml
+++ b/examples/aws_managed/yamls/ClusterRole-ReadWrite.yaml
@@ -1,0 +1,78 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: read-write
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - endpoints
+      - events
+      - persistentvolumeclaims
+      - pods
+      - pods/log
+      - replicationcontrollers
+      - secrets
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - apps
+    resources:
+      - daemonsets
+      - deployments
+      - replicasets
+      - statefulsets
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - batch
+    resources:
+      - cronjobs
+      - jobs
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - autoscaling
+    resources:
+      - horizontalpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+      - networkpolicies
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete

--- a/examples/aws_managed/yamls/ClusterRoleBinding-ReadWrite.yaml
+++ b/examples/aws_managed/yamls/ClusterRoleBinding-ReadWrite.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: read-write
+subjects:
+  - kind: Group
+    name: read-write
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: read-write
+  apiGroup: rbac.authorization.k8s.io

--- a/examples/aws_managed/yamls/ClusterRoleBinding-View.yaml
+++ b/examples/aws_managed/yamls/ClusterRoleBinding-View.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: view
+subjects:
+  - kind: Group
+    name: view
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: view
+  apiGroup: rbac.authorization.k8s.io

--- a/examples/aws_managed/yamls/RoleBinding-ReadWrite-Namespace.yaml
+++ b/examples/aws_managed/yamls/RoleBinding-ReadWrite-Namespace.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: namespace-read-write
+  namespace: default
+subjects:
+  - kind: Group
+    name: namespace-read-write
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: read-write
+  apiGroup: rbac.authorization.k8s.io

--- a/examples/aws_managed/yamls/RoleBinding-View-Namespace.yaml
+++ b/examples/aws_managed/yamls/RoleBinding-View-Namespace.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: namespace-view
+  namespace: default
+subjects:
+  - kind: Group
+    name: namespace-view
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: view
+  apiGroup: rbac.authorization.k8s.io

--- a/examples/aws_managed_with_fargate/versions.tf
+++ b/examples/aws_managed_with_fargate/versions.tf
@@ -9,7 +9,7 @@ terraform {
     }
     cloudinit = {
       source  = "hashicorp/cloudinit"
-      version = ">= 5.80.0"
+      version = ">= 2.0.0"
     }
   }
 }

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -9,7 +9,7 @@ terraform {
     }
     cloudinit = {
       source  = "hashicorp/cloudinit"
-      version = ">= 5.80.0"
+      version = ">= 2.0.0"
     }
   }
 }

--- a/examples/eks-nodegroup-with-existing-cluster/versions.tf
+++ b/examples/eks-nodegroup-with-existing-cluster/versions.tf
@@ -9,7 +9,7 @@ terraform {
     }
     cloudinit = {
       source  = "hashicorp/cloudinit"
-      version = ">= 5.80.0"
+      version = ">= 2.0.0"
     }
   }
 }

--- a/examples/self_managed/versions.tf
+++ b/examples/self_managed/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     cloudinit = {
       source  = "hashicorp/cloudinit"
-      version = ">= 5.80.0"
+      version = ">= 2.0.0"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -12,5 +12,5 @@ terraform {
   provider_meta "aws" {
     module_name = "clouddrove/terraform-aws-eks"
   }
- }
+}
 

--- a/versions.tf
+++ b/versions.tf
@@ -12,5 +12,5 @@ terraform {
   provider_meta "aws" {
     module_name = "clouddrove/terraform-aws-eks"
   }
-}
+ }
 

--- a/versions.tf
+++ b/versions.tf
@@ -10,7 +10,7 @@ terraform {
   }
 
   provider_meta "aws" {
-    module_name = "clouddrove/terraform-aws-eks"
+    user_agent = ["github.com/clouddrove/terraform-aws-eks"]
   }
 }
 


### PR DESCRIPTION
## 📌 Description

This PR updates the `examples/aws_managed` example to demonstrate how to configure read-only access to an EKS cluster for AWS SSO/IAM role based users.

The example now maps an additional IAM role to the Kubernetes `view` group using `map_additional_iam_roles`, and adds a `ClusterRoleBinding` manifest to bind the `view` group to the built-in Kubernetes `view` ClusterRole. The YAML manifest is applied using the `kubectl_manifest` Terraform resource.

This helps users create and assign read-only EKS access through Terraform instead of manually applying RBAC manifests with `kubectl`.

---

## 🔄 Type of Change

* [ ] 🐛 Bug fix (non-breaking change)
* [x] ✨ New resource / feature
* [ ] ♻️ Refactoring
* [ ] ⚡ Performance improvement
* [x] 🔒 Security improvement
* [ ] 📝 Documentation update
* [ ] ⚠️ BREAKING CHANGE
* [ ] ⚙️ CI/CD update

---

## 🌍 Terraform Scope

* [x] New resource added
* [ ] Existing resource updated
* [ ] Variable(s) modified
* [ ] Output(s) modified
* [x] Provider / backend configuration change
* [ ] CI/CD (Terraform workflow) update
* [x] Examples / usage updated

---

## ✅ Checklist

* [x] Code follows Terraform best practices
* [x] `terraform fmt -recursive` and `terraform validate` have been executed
* [x] `terraform plan` has been reviewed and changes are expected
* [x] Changes are backward compatible (or breaking changes are clearly documented)
* [x] Documentation has been updated (README, examples, etc.)
* [ ] Variables and outputs are properly defined and documented
* [x] No sensitive data (secrets, credentials, keys) is exposed

---

## 🧩 Terraform Version & Providers

* Terraform Version: `>= 1.10.0`
* Provider(s):
  * `hashicorp/aws >= 5.80.0`
  * `hashicorp/cloudinit >= 2.0`
  * `gavinbunney/kubectl >= 1.19.0`

---

## 🧪 Testing

* [x] Tested locally using `terraform plan` / `apply`
* [x] Tested in a staging / sandbox environment

**Test Details:**

- Verified `aws-auth` ConfigMap includes the additional IAM role mapping under `mapRoles`.
- Verified the role is mapped to Kubernetes group `view`.
- Verified `ClusterRoleBinding-View.yaml` is applied through `kubectl_manifest`.
- Confirmed read-only user can list Kubernetes resources.
- Confirmed read-only user cannot modify/delete Kubernetes resources.

---

## 📸 Screenshots / Documentation

N/A

---

## 🔗 Related Issues

Closes #

---

## 📝 Additional Notes

This example uses the built-in Kubernetes `view` ClusterRole. Since the `view` group does not receive permissions automatically, this PR adds a `ClusterRoleBinding` to bind the `view` group to the `view` ClusterRole.
